### PR TITLE
fix: narrow uses insufficient input char type

### DIFF
--- a/include/boost/date_time/posix_time/posix_time_legacy_io.hpp
+++ b/include/boost/date_time/posix_time/posix_time_legacy_io.hpp
@@ -80,7 +80,7 @@ namespace posix_time {
     // any marker (such as '\0').
     typename std::basic_string<charT>::iterator e = inp_s.end();
     while(b != e){
-      out_ss << out_ss.narrow(*b, 0);
+      out_ss << is.narrow(*b, 0);
       ++b;
     }
 


### PR DESCRIPTION
The current implementation uses std::stringstream::narrow(char) with its 'char' input parameter type to transform 'charT' chars taken from a std::basic_istream<charT> into 'char' chars. This is most likely not what is intended if 'charT' is wider than 'char'. Fix this by using std::basic_istream<charT>::narrow(charT) instead.

Signed-off-by: Daniela Engert dani@ngrt.de
