### PR TITLE
Suppress msvc level-4 warnings.

### DIFF
--- a/include/boost/date_time/date_clock_device.hpp
+++ b/include/boost/date_time/date_clock_device.hpp
@@ -36,18 +36,18 @@ namespace date_time {
     {
       ::std::tm result;
       ::std::tm* curr = get_local_time(result);
-      return ymd_type(curr->tm_year + 1900, 
-                      curr->tm_mon + 1, 
-                      curr->tm_mday);
+      return ymd_type(static_cast<unsigned short>(curr->tm_year + 1900),
+                      static_cast<unsigned short>(curr->tm_mon + 1),
+                      static_cast<unsigned short>(curr->tm_mday));
     }
     //! Get the current day in universal date as a ymd_type
     static typename date_type::ymd_type universal_day_ymd() 
     {
       ::std::tm result;
       ::std::tm* curr = get_universal_time(result);
-      return ymd_type(curr->tm_year + 1900, 
-                      curr->tm_mon + 1, 
-                      curr->tm_mday);
+      return ymd_type(static_cast<unsigned short>(curr->tm_year + 1900),
+                      static_cast<unsigned short>(curr->tm_mon + 1),
+                      static_cast<unsigned short>(curr->tm_mday));
     }
     //! Get the UTC day as a date type
     static date_type universal_day() 

--- a/include/boost/date_time/format_date_parser.hpp
+++ b/include/boost/date_time/format_date_parser.hpp
@@ -63,7 +63,7 @@ fixed_string_to_int(std::istreambuf_iterator<charT>& itr,
     itr++;
     j++;
   }
-  int_type i = -1;
+  int_type i = static_cast<int_type>(-1);
   // mr.cache will hold leading zeros. size() tells us when input is too short.
   if(mr.cache.size() < length) {
     return i;
@@ -111,7 +111,7 @@ var_string_to_int(std::istreambuf_iterator<charT>& itr,
     ++itr;
     ++j;
   }
-  int_type i = -1;
+  int_type i = static_cast<int_type>(-1);
   if(!s.empty()) {
     i = boost::lexical_cast<int_type>(s);
   }

--- a/include/boost/date_time/gregorian/greg_facet.hpp
+++ b/include/boost/date_time/gregorian/greg_facet.hpp
@@ -97,7 +97,7 @@ namespace gregorian {
     std::locale locale = os.getloc();
     if (std::has_facet<facet_def>(locale)) {
       const facet_def& f = std::use_facet<facet_def>(locale);
-      greg_weekday_formatter::format_weekday(wd.as_enum(), os, f, true);
+      greg_weekday_formatter::format_weekday(wd, os, f, true);
     }
     else { //default to short English string eg: Sun, Mon, Tue, Wed...
       os  << wd.as_short_string();

--- a/include/boost/date_time/local_time/posix_time_zone.hpp
+++ b/include/boost/date_time/local_time/posix_time_zone.hpp
@@ -430,9 +430,9 @@ namespace local_time{
       dst_calc_rules_ = shared_ptr<dst_calc_rule>(
         new partial_date_dst_rule(
           partial_date_dst_rule::start_rule(
-            sd, static_cast<date_time::months_of_year>(sm)),
+            static_cast<unsigned short>(sd), static_cast<date_time::months_of_year>(sm)),
           partial_date_dst_rule::end_rule(
-            ed, static_cast<date_time::months_of_year>(em))
+            static_cast<unsigned short>(ed), static_cast<date_time::months_of_year>(em))
           )
       );
     }

--- a/include/boost/date_time/tz_db_base.hpp
+++ b/include/boost/date_time/tz_db_base.hpp
@@ -261,8 +261,12 @@ namespace boost {
         e_wn = get_week_num(e_nth);
         
         
-        return new rule_type(start_rule(s_wn, s_d, s_m),
-                             end_rule(e_wn, e_d, e_m));
+        return new rule_type(start_rule(s_wn,
+                                        static_cast<unsigned short>(s_d),
+                                        static_cast<unsigned short>(s_m)),
+                             end_rule(e_wn,
+                                      static_cast<unsigned short>(e_d),
+                                      static_cast<unsigned short>(e_m)));
       }
       //! helper function for parse_rules()
       week_num get_week_num(int nth) const


### PR DESCRIPTION
Even when compiled at warning level 4 (i.e. all), project policies may require compilations without warnings issued.

Signed-off-by: Daniela Engert dani@ngrt.de
