### PR TITLE
Fix for utc_to_local year 2038 problem

### DIFF
--- a/include/boost/date_time/c_local_time_adjustor.hpp
+++ b/include/boost/date_time/c_local_time_adjustor.hpp
@@ -42,7 +42,10 @@ namespace date_time {
       }
       date_duration_type dd = t.date() - time_t_start_day;
       time_duration_type td = t.time_of_day();
-      std::time_t t2 = dd.days()*86400 + td.hours()*3600 + td.minutes()*60 + td.seconds();
+      std::time_t t2 = static_cast<std::time_t>(dd.days())*86400 +
+                       static_cast<std::time_t>(td.hours())*3600 +
+                       static_cast<std::time_t>(td.minutes())*60 +
+                       td.seconds();
       std::tm tms, *tms_ptr;
       tms_ptr = c_time::localtime(&t2, &tms);
       date_type d(static_cast<unsigned short>(tms_ptr->tm_year + 1900),


### PR DESCRIPTION
Even if std::time_t is 64-bit, multiplying the 32-bit value dd.days() by 86400 results in a negative value for dates after 2038. This results in c_time::localtime(&t2, &tms) throwing an exception.

Adding casts to std::time_t fixes this problem.
