### PR TITLE
Fix locally defined but unused typedef warnings on GCC.

### DIFF
--- a/include/boost/date_time/date_parsing.hpp
+++ b/include/boost/date_time/date_parsing.hpp
@@ -113,7 +113,6 @@ namespace date_time {
         spec_str = "mdy";
       }
 
-      typedef typename date_type::year_type year_type;
       typedef typename date_type::month_type month_type;
       unsigned pos = 0;
       unsigned short year(0), month(0), day(0);
@@ -160,7 +159,6 @@ namespace date_time {
     parse_undelimited_date(const std::string& s) {
       int offsets[] = {4,2,2};
       int pos = 0;
-      typedef typename date_type::year_type year_type;
       //typename date_type::ymd_type ymd((year_type::min)(),1,1);
       unsigned short y = 0, m = 0, d = 0;
 

--- a/include/boost/date_time/gregorian/greg_facet.hpp
+++ b/include/boost/date_time/gregorian/greg_facet.hpp
@@ -214,8 +214,6 @@ namespace gregorian {
   std::basic_istream<charT>& operator>>(std::basic_istream<charT>& is, date& d)
   {
     std::istream_iterator<std::basic_string<charT>, charT> beg(is), eos;
-    
-    typedef boost::date_time::all_date_names_put<greg_facet_config, charT> facet_def;
     d = from_stream(beg, eos);
     return is;
   }

--- a/include/boost/date_time/local_time/local_time_io.hpp
+++ b/include/boost/date_time/local_time/local_time_io.hpp
@@ -36,7 +36,6 @@ namespace local_time {
     boost::io::ios_flags_saver iflags(os);
     typedef local_date_time time_type;//::utc_time_type typename 
     typedef date_time::time_facet<time_type, CharT> custom_time_facet;
-    typedef std::time_put<CharT> std_time_facet;
     std::ostreambuf_iterator<CharT> oitr(os);
 
     if(std::has_facet<custom_time_facet>(os.getloc())) {
@@ -123,7 +122,6 @@ namespace local_time {
              const boost::local_time::local_time_period& p) {
     boost::io::ios_flags_saver iflags(os);
     typedef boost::date_time::time_facet<local_date_time, CharT> custom_facet;
-    typedef std::time_put<CharT> std_time_facet;
     std::ostreambuf_iterator<CharT> oitr(os);
     if (std::has_facet<custom_facet>(os.getloc())) {
       std::use_facet<custom_facet>(os.getloc()).put(oitr, os, os.fill(), p);

--- a/include/boost/date_time/posix_time/posix_time_io.hpp
+++ b/include/boost/date_time/posix_time/posix_time_io.hpp
@@ -47,7 +47,6 @@ namespace posix_time {
              const ptime& p) {
     boost::io::ios_flags_saver iflags(os);
     typedef boost::date_time::time_facet<ptime, CharT> custom_ptime_facet;
-    typedef std::time_put<CharT>                  std_ptime_facet;
     std::ostreambuf_iterator<CharT> oitr(os);
     if (std::has_facet<custom_ptime_facet>(os.getloc()))
       std::use_facet<custom_ptime_facet>(os.getloc()).put(oitr, os, os.fill(), p);
@@ -114,7 +113,6 @@ namespace posix_time {
              const boost::posix_time::time_period& p) {
     boost::io::ios_flags_saver iflags(os);
     typedef boost::date_time::time_facet<ptime, CharT> custom_ptime_facet;
-    typedef std::time_put<CharT>                  std_time_facet;
     std::ostreambuf_iterator<CharT> oitr(os);
     if (std::has_facet<custom_ptime_facet>(os.getloc())) {
       std::use_facet<custom_ptime_facet>(os.getloc()).put(oitr, os, os.fill(), p);
@@ -180,7 +178,6 @@ namespace posix_time {
   {
     boost::io::ios_flags_saver iflags(os);
     typedef boost::date_time::time_facet<ptime, CharT> custom_ptime_facet;
-    typedef std::time_put<CharT>                  std_ptime_facet;
     std::ostreambuf_iterator<CharT> oitr(os);
     if (std::has_facet<custom_ptime_facet>(os.getloc()))
       std::use_facet<custom_ptime_facet>(os.getloc()).put(oitr, os, os.fill(), td);

--- a/include/boost/date_time/string_convert.hpp
+++ b/include/boost/date_time/string_convert.hpp
@@ -21,7 +21,6 @@ namespace date_time {
   inline
   std::basic_string<OutputT> convert_string_type(const std::basic_string<InputT>& inp_str)
   {
-    typedef std::basic_string<InputT> input_type;
     typedef std::basic_string<OutputT> output_type;
     output_type result;
     result.insert(result.begin(), inp_str.begin(), inp_str.end());

--- a/include/boost/date_time/strings_from_facet.hpp
+++ b/include/boost/date_time/strings_from_facet.hpp
@@ -35,7 +35,6 @@ gather_month_strings(const std::locale& locale, bool short_strings=true)
 {
   typedef std::basic_string<charT> string_type;
   typedef std::vector<string_type> collection_type;
-  typedef std::basic_ostringstream<charT> ostream_type;
   typedef std::ostreambuf_iterator<charT> ostream_iter_type;
   typedef std::basic_ostringstream<charT> stringstream_type;
   typedef std::time_put<charT>           time_put_facet_type;
@@ -86,7 +85,6 @@ gather_weekday_strings(const std::locale& locale, bool short_strings=true)
 {
   typedef std::basic_string<charT> string_type;
   typedef std::vector<string_type> collection_type;
-  typedef std::basic_ostringstream<charT> ostream_type;
   typedef std::ostreambuf_iterator<charT> ostream_iter_type;
   typedef std::basic_ostringstream<charT> stringstream_type;
   typedef std::time_put<charT>           time_put_facet_type;


### PR DESCRIPTION
The commit removes unused typedefs that cause warnings on recent GCC versions. These warnings often propagate to other libraries which use Boost.DateTime.
