### PR TITLE
Added test for bug #5041 - %y in single digit year

### DIFF
--- a/test/gregorian/testdate_facet_new.cpp
+++ b/test/gregorian/testdate_facet_new.cpp
@@ -222,6 +222,13 @@ int main() {
                     std::string("2004-Oct-13 %13"), 
                     std::locale(std::locale::classic(), datefacet));
     }
+    {
+      date d1(2004,Oct, 13);
+      date_facet* datefacet = new date_facet("%d%m%y");
+      teststreaming("Single digit year and %y", d1,
+                    std::string("131004"), 
+                    std::locale(std::locale::classic(), datefacet));
+    }
     {//month
       date_facet* datefacet = new date_facet();
       datefacet->month_format("%b %%b");


### PR DESCRIPTION
I was unable to replicate this bug ; it appears that it was already fixed.
However, I added a test for it.
