### PR TITLE
Add some automatic checks to testc_local_adjustor.

### DIFF
--- a/test/posix_time/testc_local_adjustor.cpp
+++ b/test/posix_time/testc_local_adjustor.cpp
@@ -41,6 +41,37 @@ main()
   std::cout << "A difference of: " << to_simple_string(td2)
             << std::endl;
 
+  ptime t5(date(2040,May,1), hours(5)+millisec(5));
+  std::cout << "UTC <--> TZ Setting of Machine -- In DST" << std::endl;
+  ptime t6 = local_adj::utc_to_local(t5);
+  std::cout << to_simple_string(t6) << " LOCAL is " 
+            << to_simple_string(t5) << " UTC time "
+            << std::endl;
+  time_duration td3 = t6 - t5;
+  std::cout << "a difference of: " << to_simple_string(td3)
+            << std::endl;
+
+  // The following tests are unaware of the local time zone, but they
+  // should help spot some errors. Manual inspection could still be
+  // required.
+
+  // Based on http://stackoverflow.com/questions/8131023
+  // All time zones are between -12 and +14
+  check("td1 isn't too low", td1 >= hours(-12));
+  check("td1 isn't too high", td1 <= hours(14));
+  check("td2 isn't too low", td2 >= hours(-12));
+  check("td2 isn't too high", td2 <= hours(14));
+  check("td3 isn't too low", td3 >= hours(-12));
+  check("td3 isn't too high", td3 <= hours(14));
+
+  // Assuming that no one uses DST of more than an hour.
+  check("td1 and td2 are close",
+          td1 - td2 <= hours(1) && td2 - td1 <= hours(1));
+  check("td2 and td3 are close",
+          td2 - td3 <= hours(2) && td3 - td2 <= hours(2));
+  check("td1 and td3 are close",
+          td1 - td3 <= hours(1) && td3 - td1 <= hours(1));
+
   return printTestStats();
 }
 


### PR DESCRIPTION
Test for 344c0dceb44ee0d0767ff041c2e627fdc9e45bab. It fails on 32-bit linux, which still uses 32-bit `std::time_t`. Since this is a posix wrapper, and this bug is due to a limitation of posix, I don't know if it's considered acceptable or not.
