### PR TITLE
Fix Boost.Sync tests breakage.

### DIFF
--- a/include/boost/date_time/time.hpp
+++ b/include/boost/date_time/time.hpp
@@ -49,6 +49,7 @@ namespace date_time {
       > >
   {
   public:
+    // A tag for type categorization. Can be used to detect Boost.DateTime time points in generic code.
     typedef void _is_boost_date_time_time_point;
     typedef T time_type;
     typedef typename time_system::time_rep_type time_rep_type;

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -42,6 +42,7 @@ namespace date_time {
    * either (haven't tried) */
   {
   public:
+    // A tag for type categorization. Can be used to detect Boost.DateTime duration types in generic code.
     typedef void _is_boost_date_time_duration;
     typedef T duration_type;  //the subclass
     typedef rep_type traits_type;


### PR DESCRIPTION
Re-add date/time type tags removed by commit 6636f49f13154555b3b9c9618fca5f03cf47a5b3. These tags are used by Boost.Sync to categorize different date/time types.
