### PR TITLE
Variable v_type conflicts with the definition of an AIX system variable.

### DIFF
--- a/include/boost/date_time/time_resolution_traits.hpp
+++ b/include/boost/date_time/time_resolution_traits.hpp
@@ -68,6 +68,10 @@ namespace date_time {
            typename frac_sec_type::int_type resolution_adjust,
 #endif
            unsigned short frac_digits,
+#ifdef _AIX
+           // In AIX, v_type conflicts with the definiton of a system variable.
+           #undef v_type
+#endif
            typename v_type = boost::int32_t >
   class time_resolution_traits {
   public:


### PR DESCRIPTION
This variable conflicts with the definition of an AIX variable and as a result some of the interprocess_example tests fail. By undefining the variable, I free the name so that it can be reused.
