### PR TITLE
Restore stream format state after using month_formatter::format_month

### DIFF
--- a/include/boost/date_time/date_formatting.hpp
+++ b/include/boost/date_time/date_formatting.hpp
@@ -51,7 +51,11 @@ namespace date_time {
         }
         case month_as_integer: 
         { 
-          os << std::setw(2) << std::setfill(os.widen('0')) << month.as_number();
+          std::streamsize old_width = os.width();
+          ostream_type::char_type old_fill = os.fill();
+
+          os << std::setw(2) << std::setfill(os.widen('0')) << month.as_number()
+             << std::setw(old_width) << std::setfill(old_fill);
           break;
         }
         default:


### PR DESCRIPTION
`date_time::month_formatter` alters the format state of an output stream that is passed in by changing the `width` and `fill` characters but never restores them. This can result in unexpected output when using this function.

Save the old `width` and `fill` character and restore them, effectively putting the stream back to its original format state before returning.

I've only tested this on gcc 4.8.1, but it uses only functionality available in the standard library.
