### PR TITLE
Add support for hidden visibility

### DIFF
--- a/include/boost/date_time/c_time.hpp
+++ b/include/boost/date_time/c_time.hpp
@@ -57,15 +57,15 @@ namespace date_time {
       static std::tm* localtime(const std::time_t* t, std::tm* result)
       {
         // localtime_r() not in namespace std???
- 	#if defined(__VMS) && __INITIAL_POINTER_SIZE == 64
- 	std::tm tmp;
- 	if(!localtime_r(t,&tmp))
+#if defined(__VMS) && __INITIAL_POINTER_SIZE == 64
+        std::tm tmp;
+        if(!localtime_r(t,&tmp))
             result = 0;
-	else
-            *result = tmp;	
- 	#else
+        else
+            *result = tmp;
+#else
         result = localtime_r(t, result);
-	#endif
+#endif
         if (!result)
           boost::throw_exception(std::runtime_error("could not convert calendar time to local time"));
         return result;
@@ -75,15 +75,15 @@ namespace date_time {
       static std::tm* gmtime(const std::time_t* t, std::tm* result)
       {
         // gmtime_r() not in namespace std???
- 	#if defined(__VMS) && __INITIAL_POINTER_SIZE == 64
- 	std::tm tmp;
- 	if(!gmtime_r(t,&tmp))
+#if defined(__VMS) && __INITIAL_POINTER_SIZE == 64
+        std::tm tmp;
+        if(!gmtime_r(t,&tmp))
           result = 0;
         else
-          *result = tmp;	
-	#else
+          *result = tmp;
+#else
         result = gmtime_r(t, result);
-	#endif
+#endif
         if (!result)
           boost::throw_exception(std::runtime_error("could not convert calendar time to UTC time"));
         return result;

--- a/include/boost/date_time/constrained_value.hpp
+++ b/include/boost/date_time/constrained_value.hpp
@@ -39,7 +39,7 @@ namespace CV {
    *
    */
   template<class value_policies>
-  class constrained_value {
+  class BOOST_SYMBOL_VISIBLE constrained_value {
   public:
     typedef typename value_policies::value_type value_type;
     //    typedef except_type exception_type;
@@ -80,9 +80,9 @@ namespace CV {
   //! Template to shortcut the constrained_value policy creation process
   template<typename rep_type, rep_type min_value, 
            rep_type max_value, class exception_type>
-  class simple_exception_policy
+  class BOOST_SYMBOL_VISIBLE simple_exception_policy
   {
-    struct exception_wrapper : public exception_type
+    struct BOOST_SYMBOL_VISIBLE exception_wrapper : public exception_type
     {
       // In order to support throw_exception mechanism in the BOOST_NO_EXCEPTIONS mode,
       // we'll have to provide a way to acquire std::exception from the exception being thrown.

--- a/include/boost/date_time/date.hpp
+++ b/include/boost/date_time/date.hpp
@@ -10,6 +10,7 @@
  */
 
 #include <boost/operators.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/year_month_day.hpp>
 #include <boost/date_time/special_defs.hpp>
 
@@ -50,7 +51,7 @@ namespace date_time {
 
 
   template<class T, class calendar, class duration_type_>
-  class date : private
+  class BOOST_SYMBOL_VISIBLE date : private
        boost::less_than_comparable<T
      , boost::equality_comparable<T
     > >

--- a/include/boost/date_time/date_duration.hpp
+++ b/include/boost/date_time/date_duration.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/operators.hpp>
 #include <boost/date_time/special_defs.hpp>
+#include <boost/date_time/compiler_config.hpp>
 
 namespace boost {
 namespace date_time {
@@ -19,7 +20,7 @@ namespace date_time {
 
   //! Duration type with date level resolution
   template<class duration_rep_traits>
-  class date_duration : private
+  class BOOST_SYMBOL_VISIBLE date_duration : private
               boost::less_than_comparable1< date_duration< duration_rep_traits >
             , boost::equality_comparable1< date_duration< duration_rep_traits >
             , boost::addable1< date_duration< duration_rep_traits >
@@ -121,7 +122,7 @@ namespace date_time {
   /*! Struct for instantiating date_duration with <b>NO</b> special values
    * functionality. Allows for transparent implementation of either
    * date_duration<long> or date_duration<int_adapter<long> > */
-  struct duration_traits_long
+  struct BOOST_SYMBOL_VISIBLE duration_traits_long
   {
     typedef long int_type;
     typedef long impl_type;
@@ -131,7 +132,7 @@ namespace date_time {
   /*! Struct for instantiating date_duration <b>WITH</b> special values
    * functionality. Allows for transparent implementation of either
    * date_duration<long> or date_duration<int_adapter<long> > */
-  struct duration_traits_adapted
+  struct BOOST_SYMBOL_VISIBLE duration_traits_adapted
   {
     typedef long int_type;
     typedef boost::date_time::int_adapter<long> impl_type;

--- a/include/boost/date_time/date_duration_types.hpp
+++ b/include/boost/date_time/date_duration_types.hpp
@@ -8,7 +8,8 @@
  * Author: Jeff Garland, Bart Garst
  * $Date$
  */
-                                                                                
+
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/int_adapter.hpp>
 #include <boost/date_time/special_defs.hpp>
 #include <boost/date_time/date_duration.hpp>
@@ -19,7 +20,7 @@ namespace date_time {
 
   //! Additional duration type that represents a number of n*7 days
   template <class duration_config>
-  class weeks_duration : public date_duration<duration_config> {
+  class BOOST_SYMBOL_VISIBLE weeks_duration : public date_duration<duration_config> {
   public:
     weeks_duration(typename duration_config::impl_type w) 
       : date_duration<duration_config>(w * 7) {}
@@ -29,7 +30,7 @@ namespace date_time {
 
   // predeclare
   template<class t>
-  class years_duration;
+  class BOOST_SYMBOL_VISIBLE years_duration;
 
   //! additional duration type that represents a logical month
   /*! A logical month enables things like: "date(2002,Mar,2) + months(2) -> 
@@ -37,7 +38,7 @@ namespace date_time {
    * also be a last-day-of-the-month.
    */
   template<class base_config>
-  class months_duration 
+  class BOOST_SYMBOL_VISIBLE months_duration
   {
     private:
       typedef typename base_config::int_rep int_rep;
@@ -159,7 +160,7 @@ namespace date_time {
    * 2004-Feb-29).
    */
   template<class base_config>
-  class years_duration 
+  class BOOST_SYMBOL_VISIBLE years_duration
   {
     private:
       typedef typename base_config::int_rep int_rep;

--- a/include/boost/date_time/date_facet.hpp
+++ b/include/boost/date_time/date_facet.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace date_time {
   template <class date_type,
             class CharT,
             class OutItrT = std::ostreambuf_iterator<CharT, std::char_traits<CharT> > >
-  class date_facet : public std::locale::facet {
+  class BOOST_SYMBOL_VISIBLE date_facet : public std::locale::facet {
   public:
     typedef typename date_type::duration_type duration_type;
     // greg_weekday is gregorian_calendar::day_of_week_type
@@ -408,7 +408,7 @@ namespace boost { namespace date_time {
   template <class date_type,
             class CharT,
             class InItrT = std::istreambuf_iterator<CharT, std::char_traits<CharT> > >
-  class date_input_facet : public std::locale::facet {
+  class BOOST_SYMBOL_VISIBLE date_input_facet : public std::locale::facet {
   public:
     typedef typename date_type::duration_type duration_type;
     // greg_weekday is gregorian_calendar::day_of_week_type

--- a/include/boost/date_time/date_names_put.hpp
+++ b/include/boost/date_time/date_names_put.hpp
@@ -10,15 +10,15 @@
  */
 
 
-#include "boost/date_time/locale_config.hpp" // set BOOST_DATE_TIME_NO_LOCALE
+#include <boost/date_time/locale_config.hpp> // set BOOST_DATE_TIME_NO_LOCALE
 
 #ifndef BOOST_DATE_TIME_NO_LOCALE
 
-#include "boost/date_time/compiler_config.hpp"
-#include "boost/date_time/special_defs.hpp"
-#include "boost/date_time/date_defs.hpp"
-#include "boost/date_time/parse_format_base.hpp"
-#include "boost/lexical_cast.hpp"
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/special_defs.hpp>
+#include <boost/date_time/date_defs.hpp>
+#include <boost/date_time/parse_format_base.hpp>
+#include <boost/lexical_cast.hpp>
 #include <locale>
 
 

--- a/include/boost/date_time/date_names_put.hpp
+++ b/include/boost/date_time/date_names_put.hpp
@@ -14,6 +14,7 @@
 
 #ifndef BOOST_DATE_TIME_NO_LOCALE
 
+#include "boost/date_time/compiler_config.hpp"
 #include "boost/date_time/special_defs.hpp"
 #include "boost/date_time/date_defs.hpp"
 #include "boost/date_time/parse_format_base.hpp"
@@ -39,7 +40,7 @@ namespace date_time {
     template<class Config,
              class charT = char,
              class OutputIterator = std::ostreambuf_iterator<charT> >
-    class date_names_put : public std::locale::facet
+    class BOOST_SYMBOL_VISIBLE date_names_put : public std::locale::facet
     {
     public:
       date_names_put() {}
@@ -208,7 +209,7 @@ namespace date_time {
     template<class Config,
              class charT = char,
              class OutputIterator = std::ostreambuf_iterator<charT> >
-    class all_date_names_put : public date_names_put<Config, charT, OutputIterator>
+    class BOOST_SYMBOL_VISIBLE all_date_names_put : public date_names_put<Config, charT, OutputIterator>
     {
     public:
       all_date_names_put(const charT* const month_short_names[],

--- a/include/boost/date_time/gregorian/greg_calendar.hpp
+++ b/include/boost/date_time/gregorian/greg_calendar.hpp
@@ -10,6 +10,7 @@
  */
 
 #include <boost/cstdint.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/gregorian/greg_weekday.hpp>
 #include <boost/date_time/gregorian/greg_day_of_year.hpp>
 #include <boost/date_time/gregorian_calendar.hpp>
@@ -23,7 +24,7 @@ namespace gregorian {
   typedef date_time::int_adapter<uint32_t> fancy_date_rep;
 
   //! Gregorian calendar for this implementation, hard work in the base
-  class gregorian_calendar :
+  class BOOST_SYMBOL_VISIBLE gregorian_calendar :
     public date_time::gregorian_calendar_base<greg_year_month_day, fancy_date_rep::int_type> {
   public:
     //! Type to hold a weekday (eg: Sunday, Monday,...)

--- a/include/boost/date_time/gregorian/greg_date.hpp
+++ b/include/boost/date_time/gregorian/greg_date.hpp
@@ -10,6 +10,7 @@
  */
 
 #include <boost/throw_exception.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/date.hpp>
 #include <boost/date_time/special_defs.hpp>
 #include <boost/date_time/gregorian/greg_calendar.hpp>
@@ -34,7 +35,7 @@ namespace gregorian {
       supported.
       \ingroup date_basics
   */
-  class date : public date_time::date<date, gregorian_calendar, date_duration>
+  class BOOST_SYMBOL_VISIBLE date : public date_time::date<date, gregorian_calendar, date_duration>
   {
    public:
     typedef gregorian_calendar::year_type year_type;

--- a/include/boost/date_time/gregorian/greg_day.hpp
+++ b/include/boost/date_time/gregorian/greg_day.hpp
@@ -9,7 +9,8 @@
  * $Date$
  */
 
-#include "boost/date_time/constrained_value.hpp"
+#include <boost/date_time/constrained_value.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <stdexcept>
 #include <string>
 
@@ -17,7 +18,7 @@ namespace boost {
 namespace gregorian {
 
   //! Exception type for gregorian day of month (1..31)
-  struct bad_day_of_month : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_day_of_month : public std::out_of_range
   {
     bad_day_of_month() : 
       std::out_of_range(std::string("Day of month value is out of range 1..31")) 
@@ -39,7 +40,7 @@ namespace gregorian {
       is automatically range checked so values outside of the range 1-31
       will cause a bad_day_of_month exception
   */
-  class greg_day : public greg_day_rep {
+  class BOOST_SYMBOL_VISIBLE greg_day : public greg_day_rep {
   public:
     greg_day(unsigned short day_of_month) : greg_day_rep(day_of_month) {}
     unsigned short as_number() const {return value_;}

--- a/include/boost/date_time/gregorian/greg_day_of_year.hpp
+++ b/include/boost/date_time/gregorian/greg_day_of_year.hpp
@@ -9,7 +9,8 @@
  * $Date$
  */
 
-#include "boost/date_time/constrained_value.hpp"
+#include <boost/date_time/constrained_value.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <stdexcept>
 #include <string>
 
@@ -17,7 +18,7 @@ namespace boost {
 namespace gregorian {
 
   //! Exception type for day of year (1..366)
-  struct bad_day_of_year : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_day_of_year : public std::out_of_range
   {
     bad_day_of_year() : 
       std::out_of_range(std::string("Day of year value is out of range 1..366")) 

--- a/include/boost/date_time/gregorian/greg_duration.hpp
+++ b/include/boost/date_time/gregorian/greg_duration.hpp
@@ -9,6 +9,7 @@
  * $Date$
  */
 
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/date_duration.hpp>
 #include <boost/date_time/int_adapter.hpp>
 #include <boost/date_time/special_defs.hpp>
@@ -22,7 +23,7 @@ namespace gregorian {
   //! Durations in days for gregorian system
   /*! \ingroup date_basics
    */
-  class date_duration :
+  class BOOST_SYMBOL_VISIBLE date_duration :
     public boost::date_time::date_duration< date_duration_rep >
   {
     typedef boost::date_time::date_duration< date_duration_rep > base_type;

--- a/include/boost/date_time/gregorian/greg_duration_types.hpp
+++ b/include/boost/date_time/gregorian/greg_duration_types.hpp
@@ -1,6 +1,6 @@
 #ifndef GREG_DURATION_TYPES_HPP___
 #define GREG_DURATION_TYPES_HPP___
-                                                                                
+
 /* Copyright (c) 2004 CrystalClear Software, Inc.
  * Subject to Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
  */
 
 
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/gregorian/greg_date.hpp>
 #include <boost/date_time/int_adapter.hpp>
 #include <boost/date_time/adjust_functors.hpp>
@@ -19,7 +20,7 @@ namespace boost {
 namespace gregorian {
 
   //! config struct for additional duration types (ie months_duration<> & years_duration<>)
-  struct greg_durations_config {
+  struct BOOST_SYMBOL_VISIBLE greg_durations_config {
     typedef date date_type;
     typedef date_time::int_adapter<int> int_rep;
     typedef date_time::month_functor<date_type> month_adjustor_type; 
@@ -28,7 +29,7 @@ namespace gregorian {
   typedef date_time::months_duration<greg_durations_config> months;
   typedef date_time::years_duration<greg_durations_config> years;
 
-  class weeks_duration : public date_duration {
+  class BOOST_SYMBOL_VISIBLE weeks_duration : public date_duration {
   public:
     weeks_duration(duration_rep w) 
       : date_duration(w * 7) {}

--- a/include/boost/date_time/gregorian/greg_facet.hpp
+++ b/include/boost/date_time/gregorian/greg_facet.hpp
@@ -9,9 +9,10 @@
  * $Date$
  */
 
-#include "boost/date_time/gregorian/gregorian_types.hpp"
-#include "boost/date_time/date_formatting_locales.hpp" // sets BOOST_DATE_TIME_NO_LOCALE
-#include "boost/date_time/gregorian/parsers.hpp"
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/gregorian/gregorian_types.hpp>
+#include <boost/date_time/date_formatting_locales.hpp> // sets BOOST_DATE_TIME_NO_LOCALE
+#include <boost/date_time/gregorian/parsers.hpp>
 
 //This file is basically commented out if locales are not supported
 #ifndef BOOST_DATE_TIME_NO_LOCALE
@@ -26,7 +27,7 @@ namespace boost {
 namespace gregorian {
   
   //! Configuration of the output facet template
-  struct greg_facet_config
+  struct BOOST_SYMBOL_VISIBLE greg_facet_config
   {
     typedef boost::gregorian::greg_month month_type;
     typedef boost::date_time::special_values special_value_enum;
@@ -345,8 +346,7 @@ namespace gregorian {
 
 } } //namespace gregorian
 
-#endif  
-    
-    
+#endif
+
 #endif
 

--- a/include/boost/date_time/gregorian/greg_month.hpp
+++ b/include/boost/date_time/gregorian/greg_month.hpp
@@ -9,10 +9,10 @@
  * $Date$
  */
 
-#include "boost/date_time/constrained_value.hpp"
-#include "boost/date_time/date_defs.hpp"
-#include "boost/shared_ptr.hpp"
-#include "boost/date_time/compiler_config.hpp"
+#include <boost/date_time/constrained_value.hpp>
+#include <boost/date_time/date_defs.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <stdexcept>
 #include <string>
 #include <map>
@@ -41,7 +41,7 @@ namespace gregorian {
   using date_time::NumMonths;
   
   //! Exception thrown if a greg_month is constructed with a value out of range
-  struct bad_month : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_month : public std::out_of_range
   {
     bad_month() : std::out_of_range(std::string("Month number is out of range 1..12")) {}
   };

--- a/include/boost/date_time/gregorian/greg_weekday.hpp
+++ b/include/boost/date_time/gregorian/greg_weekday.hpp
@@ -9,9 +9,9 @@
  * $Date$
  */
 
-#include "boost/date_time/constrained_value.hpp"
-#include "boost/date_time/date_defs.hpp"
-#include "boost/date_time/compiler_config.hpp"
+#include <boost/date_time/constrained_value.hpp>
+#include <boost/date_time/date_defs.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <stdexcept>
 #include <string>
 
@@ -29,7 +29,7 @@ namespace gregorian {
 
 
   //! Exception that flags that a weekday number is incorrect
-  struct bad_weekday : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_weekday : public std::out_of_range
   {
     bad_weekday() : std::out_of_range(std::string("Weekday is out of range 0..6")) {}
   };

--- a/include/boost/date_time/gregorian/greg_year.hpp
+++ b/include/boost/date_time/gregorian/greg_year.hpp
@@ -9,7 +9,8 @@
  * $Date$
  */
 
-#include "boost/date_time/constrained_value.hpp"
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/constrained_value.hpp>
 #include <stdexcept>
 #include <string>
 
@@ -17,7 +18,7 @@ namespace boost {
 namespace gregorian {
 
   //! Exception type for gregorian year
-  struct bad_year : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_year : public std::out_of_range
   {
     bad_year() : 
       std::out_of_range(std::string("Year is out of valid range: 1400..10000")) 
@@ -36,12 +37,10 @@ namespace gregorian {
       at the moment, but they are the limits of current testing of the 
       library.  As such they may be increased in the future.
   */
-  class greg_year : public greg_year_rep {
+  class BOOST_SYMBOL_VISIBLE greg_year : public greg_year_rep {
   public:
     greg_year(unsigned short year) : greg_year_rep(year) {}
     operator unsigned short()  const {return value_;}
-  private:
-    
   };
 
 

--- a/include/boost/date_time/gregorian_calendar.hpp
+++ b/include/boost/date_time/gregorian_calendar.hpp
@@ -9,6 +9,7 @@
  * $Date$
  */
 
+#include <boost/date_time/compiler_config.hpp>
 
 namespace boost {
 namespace date_time {
@@ -25,7 +26,7 @@ namespace date_time {
     @param date_int_type_ Underlying type for the date count.  Must be an arithmetic type.
   */
   template<typename ymd_type_, typename date_int_type_>
-  class gregorian_calendar_base {
+  class BOOST_SYMBOL_VISIBLE gregorian_calendar_base {
   public:
     //! define a type a date split into components
     typedef ymd_type_  ymd_type;

--- a/include/boost/date_time/local_time/local_date_time.hpp
+++ b/include/boost/date_time/local_time/local_date_time.hpp
@@ -16,6 +16,7 @@
 #include <boost/throw_exception.hpp>
 #include <boost/date_time/time.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp> //todo remove?
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/dst_rules.hpp>
 #include <boost/date_time/time_zone_base.hpp>
 #include <boost/date_time/special_defs.hpp>
@@ -25,18 +26,18 @@ namespace boost {
 namespace local_time {
 
   //! simple exception for reporting when STD or DST cannot be determined
-  struct ambiguous_result : public std::logic_error
+  struct BOOST_SYMBOL_VISIBLE ambiguous_result : public std::logic_error
   {
     ambiguous_result (std::string const& msg = std::string()) :
       std::logic_error(std::string("Daylight Savings Results are ambiguous: " + msg)) {}
   };
   //! simple exception for when time label given cannot exist
-  struct time_label_invalid : public std::logic_error
+  struct BOOST_SYMBOL_VISIBLE time_label_invalid : public std::logic_error
   {
     time_label_invalid (std::string const& msg = std::string()) :
       std::logic_error(std::string("Time label given is invalid: " + msg)) {}
   };
-  struct dst_not_valid: public std::logic_error
+  struct BOOST_SYMBOL_VISIBLE dst_not_valid: public std::logic_error
   {
     dst_not_valid(std::string const& msg = std::string()) :
       std::logic_error(std::string("is_dst flag does not match resulting dst for time label given: " + msg)) {}
@@ -61,7 +62,7 @@ namespace local_time {
    */
   template<class utc_time_=posix_time::ptime,
            class tz_type=date_time::time_zone_base<utc_time_,char> >
-  class local_date_time_base :  public date_time::base_time<utc_time_,
+  class BOOST_SYMBOL_VISIBLE local_date_time_base :  public date_time::base_time<utc_time_,
                                                             boost::posix_time::posix_time_system> {
   public:
     typedef utc_time_ utc_time_type;

--- a/include/boost/date_time/local_time/posix_time_zone.hpp
+++ b/include/boost/date_time/local_time/posix_time_zone.hpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <boost/tokenizer.hpp>
 #include <boost/throw_exception.hpp>
+#include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/time_zone_names.hpp>
 #include <boost/date_time/time_zone_base.hpp>
@@ -25,13 +26,13 @@ namespace boost{
 namespace local_time{
 
   //! simple exception for UTC and Daylight savings start/end offsets
-  struct bad_offset : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_offset : public std::out_of_range
   {
     bad_offset(std::string const& msg = std::string()) :
       std::out_of_range(std::string("Offset out of range: " + msg)) {}
   };
   //! simple exception for UTC daylight savings adjustment
-  struct bad_adjustment : public std::out_of_range
+  struct BOOST_SYMBOL_VISIBLE bad_adjustment : public std::out_of_range
   {
     bad_adjustment(std::string const& msg = std::string()) :
       std::out_of_range(std::string("Adjustment out of range: " + msg)) {}
@@ -67,7 +68,7 @@ namespace local_time{
    * http://www.worldtimezone.com/utc/utc+1200.html
    */
   template<class CharT>
-  class posix_time_zone_base : public date_time::time_zone_base<posix_time::ptime,CharT> {
+  class BOOST_SYMBOL_VISIBLE posix_time_zone_base : public date_time::time_zone_base<posix_time::ptime,CharT> {
   public:
     typedef boost::posix_time::time_duration time_duration_type;
     typedef date_time::time_zone_names_base<CharT> time_zone_names;

--- a/include/boost/date_time/period.hpp
+++ b/include/boost/date_time/period.hpp
@@ -17,7 +17,8 @@
 
 */
 
-#include "boost/operators.hpp"
+#include <boost/operators.hpp>
+#include <boost/date_time/compiler_config.hpp>
 
 
 namespace boost {
@@ -48,7 +49,7 @@ namespace date_time {
 
    */
   template<class point_rep, class duration_rep>
-  class period : private
+  class BOOST_SYMBOL_VISIBLE period : private
       boost::less_than_comparable<period<point_rep, duration_rep> 
     , boost::equality_comparable< period<point_rep, duration_rep> 
     > >

--- a/include/boost/date_time/posix_time/date_duration_operators.hpp
+++ b/include/boost/date_time/posix_time/date_duration_operators.hpp
@@ -1,6 +1,6 @@
 #ifndef DATE_DURATION_OPERATORS_HPP___
 #define DATE_DURATION_OPERATORS_HPP___
-                                                                                
+
 /* Copyright (c) 2004 CrystalClear Software, Inc.
  * Subject to the Boost Software License, Version 1.0. 
  * (See accompanying file LICENSE_1_0.txt or 

--- a/include/boost/date_time/posix_time/posix_time_config.hpp
+++ b/include/boost/date_time/posix_time/posix_time_config.hpp
@@ -54,7 +54,7 @@ namespace posix_time {
   //! Base time duration type
   /*! \ingroup time_basics
    */
-  class time_duration :
+  class BOOST_SYMBOL_VISIBLE time_duration :
     public date_time::time_duration<time_duration, time_res_traits>
   {
   public:
@@ -134,7 +134,7 @@ namespace posix_time {
     }
   };
 
-  class posix_time_system_config
+  class BOOST_SYMBOL_VISIBLE posix_time_system_config
   {
    public:
     typedef simple_time_rep time_rep_type;

--- a/include/boost/date_time/posix_time/posix_time_duration.hpp
+++ b/include/boost/date_time/posix_time/posix_time_duration.hpp
@@ -9,7 +9,8 @@
  * $Date$
  */
 
-#include "boost/date_time/posix_time/posix_time_config.hpp"
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/posix_time/posix_time_config.hpp>
 
 namespace boost {
 namespace posix_time {
@@ -17,7 +18,7 @@ namespace posix_time {
   //! Allows expression of durations as an hour count
   /*! \ingroup time_basics
    */
-  class hours : public time_duration
+  class BOOST_SYMBOL_VISIBLE hours : public time_duration
   {
   public:
     explicit hours(long h) :
@@ -28,7 +29,7 @@ namespace posix_time {
   //! Allows expression of durations as a minute count
   /*! \ingroup time_basics
    */
-  class minutes : public time_duration
+  class BOOST_SYMBOL_VISIBLE minutes : public time_duration
   {
   public:
     explicit minutes(long m) :
@@ -39,7 +40,7 @@ namespace posix_time {
   //! Allows expression of durations as a seconds count
   /*! \ingroup time_basics
    */
-  class seconds : public time_duration
+  class BOOST_SYMBOL_VISIBLE seconds : public time_duration
   {
   public:
     explicit seconds(long s) :

--- a/include/boost/date_time/posix_time/ptime.hpp
+++ b/include/boost/date_time/posix_time/ptime.hpp
@@ -9,8 +9,9 @@
  * $Date$
  */
 
-#include "boost/date_time/posix_time/posix_time_system.hpp"
-#include "boost/date_time/time.hpp"
+#include <boost/date_time/posix_time/posix_time_system.hpp>
+#include <boost/date_time/time.hpp>
+#include <boost/date_time/compiler_config.hpp>
 
 namespace boost {
 
@@ -24,11 +25,11 @@ namespace posix_time {
   using date_time::not_a_date_time;
   using date_time::max_date_time;
   using date_time::min_date_time; 
-  
+
   //! Time type with no timezone or other adjustments
   /*! \ingroup time_basics
    */
-  class ptime : public date_time::base_time<ptime, posix_time_system>
+  class BOOST_SYMBOL_VISIBLE ptime : public date_time::base_time<ptime, posix_time_system>
   {
   public:
     typedef posix_time_system time_system_type;
@@ -53,7 +54,7 @@ namespace posix_time {
     ptime() : date_time::base_time<time_type,time_system_type>(gregorian::date(not_a_date_time), time_duration_type(not_a_date_time))
     {}
 #endif // DATE_TIME_NO_DEFAULT_CONSTRUCTOR
-      
+
   };
 
 

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -31,7 +31,7 @@ namespace date_time {
       @param rep_type The time resolution traits for this duration type.
   */
   template<class T, typename rep_type>
-  class time_duration : private
+  class BOOST_SYMBOL_VISIBLE time_duration : private
       boost::less_than_comparable<T
     , boost::equality_comparable<T
     > >
@@ -265,7 +265,7 @@ namespace date_time {
    * 10 for frac_of_second and resoultion adjustment
    */
   template<class base_duration, boost::int64_t frac_of_second>
-  class subsecond_duration : public base_duration
+  class BOOST_SYMBOL_VISIBLE subsecond_duration : public base_duration
   {
   public:
     typedef typename base_duration::impl_type impl_type;

--- a/include/boost/date_time/time_facet.hpp
+++ b/include/boost/date_time/time_facet.hpp
@@ -200,7 +200,7 @@ namespace date_time {
   template <class time_type,
             class CharT,
             class OutItrT = std::ostreambuf_iterator<CharT, std::char_traits<CharT> > >
-  class time_facet :
+  class BOOST_SYMBOL_VISIBLE time_facet :
     public boost::date_time::date_facet<typename time_type::date_type , CharT, OutItrT> {
     typedef time_formats< CharT > formats_type;
    public:
@@ -693,7 +693,7 @@ namespace date_time {
   template <class time_type,
             class CharT,
             class InItrT = std::istreambuf_iterator<CharT, std::char_traits<CharT> > >
-  class time_input_facet :
+  class BOOST_SYMBOL_VISIBLE time_input_facet :
     public boost::date_time::date_input_facet<typename time_type::date_type , CharT, InItrT> {
     public:
       typedef typename time_type::date_type date_type;

--- a/include/boost/date_time/time_zone_base.hpp
+++ b/include/boost/date_time/time_zone_base.hpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <sstream>
+#include <boost/date_time/compiler_config.hpp>
 
 namespace boost {
 namespace date_time {
@@ -31,7 +32,7 @@ namespace date_time {
    * resource (hence the derivation from boost::counted_base.
    */
   template<typename time_type, typename CharT>
-  class time_zone_base  {
+  class BOOST_SYMBOL_VISIBLE time_zone_base  {
   public:
     typedef CharT char_type;
     typedef std::basic_string<CharT> string_type;

--- a/include/boost/date_time/year_month_day.hpp
+++ b/include/boost/date_time/year_month_day.hpp
@@ -9,12 +9,14 @@
  * $Date$
  */
 
+#include <boost/date_time/compiler_config.hpp>
+
 namespace boost {
 namespace date_time {
 
   //! Allow rapid creation of ymd triples of different types
   template<typename YearType, typename MonthType, typename DayType>
-  struct year_month_day_base {
+  struct BOOST_SYMBOL_VISIBLE year_month_day_base {
     year_month_day_base(YearType  year, 
                         MonthType month,
                         DayType   day);


### PR DESCRIPTION
The pull request fixes https://svn.boost.org/trac/boost/ticket/11707, as well as a few other issues:
- All locale facets are marked visible.
- All date and time types, as well as other associated types also marked visible. This is required for facets to be visible because these types are used as template parameters (gcc requires that all types in template parameters also have default visibility).
- All exception types are also marked visible.
- Converted tabs to spaces.
