### PR TITLE
Fixed a bug for parsing posix timezone: + on the west from UTC, - on the east

### DIFF
--- a/include/boost/date_time/local_time/custom_time_zone.hpp
+++ b/include/boost/date_time/local_time/custom_time_zone.hpp
@@ -106,10 +106,10 @@ namespace local_time {
       // offset
       if(base_utc_offset().is_negative()) {
         // inverting the sign guarantees we get two digits
-        ss << '-' << std::setw(2) << base_utc_offset().invert_sign().hours();
+        ss << '+' << std::setw(2) << base_utc_offset().invert_sign().hours();
       }
       else {
-        ss << '+' << std::setw(2) << base_utc_offset().hours();
+        ss << '-' << std::setw(2) << base_utc_offset().hours();
       }
       if(base_utc_offset().minutes() != 0 || base_utc_offset().seconds() != 0) {
         ss << ':' << std::setw(2) << base_utc_offset().minutes();

--- a/include/boost/date_time/local_time/posix_time_zone.hpp
+++ b/include/boost/date_time/local_time/posix_time_zone.hpp
@@ -190,10 +190,10 @@ namespace local_time{
       // offset
       if(base_utc_offset().is_negative()) {
         // inverting the sign guarantees we get two digits
-        ss << '-' << std::setw(2) << base_utc_offset().invert_sign().hours();
+        ss << '+' << std::setw(2) << base_utc_offset().invert_sign().hours();
       }
       else {
-        ss << '+' << std::setw(2) << base_utc_offset().hours();
+        ss << '-' << std::setw(2) << base_utc_offset().hours();
       }
       if(base_utc_offset().minutes() != 0 || base_utc_offset().seconds() != 0) {
         ss << ':' << std::setw(2) << base_utc_offset().minutes();
@@ -266,7 +266,7 @@ namespace local_time{
         while(sit != obj_end && !std::isalpha(*sit)){
           ss << *sit++;
         }
-        base_utc_offset_ = date_time::str_from_delimited_time_duration<time_duration_type,char_type>(ss.str());
+        base_utc_offset_ = date_time::str_from_delimited_time_duration<time_duration_type,char_type>(ss.str()).invert_sign();
         ss.str(empty_string);
 
         // base offset must be within range of -12 hours to +14 hours

--- a/test/local_time/testclocks.cpp
+++ b/test/local_time/testclocks.cpp
@@ -19,8 +19,8 @@ main()
   using namespace boost::local_time;
 
 
-  boost::shared_ptr<time_zone> az_tz(new posix_time_zone("MST-07"));
-  boost::shared_ptr<time_zone> ny_tz(new posix_time_zone("EST-05EDT,M4.1.0,M10.5.0"));
+  boost::shared_ptr<time_zone> az_tz(new posix_time_zone("MST+07"));
+  boost::shared_ptr<time_zone> ny_tz(new posix_time_zone("EST+05EDT,M4.1.0,M10.5.0"));
 
   ptime tl = second_clock::local_time();
   std::cout << to_simple_string(tl) << std::endl;

--- a/test/local_time/testcustom_time_zone.cpp
+++ b/test/local_time/testcustom_time_zone.cpp
@@ -66,13 +66,13 @@ main()
         tz1->dst_local_end_time(2003) == ptime(date(2003,Oct,30),hours(2)));
 
   check("tz1 to posix string", 
-       tz1->to_posix_string() == std::string("PST-08PDT+01,120/02:00,303/02:00"));
+       tz1->to_posix_string() == std::string("PST+08PDT+01,120/02:00,303/02:00"));
   check("tz2 to posix string", 
-       tz2->to_posix_string() == std::string("PST-08PDT+01,M4.1.0/02:00,M10.5.0/02:00"));
+       tz2->to_posix_string() == std::string("PST+08PDT+01,M4.1.0/02:00,M10.5.0/02:00"));
   check("tz3 to posix string", 
-        tz3->to_posix_string() == std::string("PST-08PDT+01,M3.5.0/02:00,M10.5.0/02:00"));
+        tz3->to_posix_string() == std::string("PST+08PDT+01,M3.5.0/02:00,M10.5.0/02:00"));
   check("tz4 to posix string", 
-        tz4->to_posix_string() == std::string("MST-07"));
+        tz4->to_posix_string() == std::string("MST+07"));
 
   // test start/end for non-dst zone
   check("has dst in non-dst zone", !tz4->has_dst());

--- a/test/local_time/testlocal_time.cpp
+++ b/test/local_time/testlocal_time.cpp
@@ -49,10 +49,10 @@ main()
   // of these operations is done in the posix_time tests
 
   try {
-    time_zone_ptr az_tz(new posix_time_zone("MST-07"));
-    time_zone_ptr ny_tz(new posix_time_zone("EST-05EDT,M4.1.0,M10.5.0"));
+    time_zone_ptr az_tz(new posix_time_zone("MST+07"));
+    time_zone_ptr ny_tz(new posix_time_zone("EST+05EDT,M4.1.0,M10.5.0"));
     // EST & EST for sydney is correct, according to zoneinfo files
-    time_zone_ptr sydney(new posix_time_zone("EST+10EST,M10.5.0,M3.5.0/03:00"));
+    time_zone_ptr sydney(new posix_time_zone("EST-10EST,M10.5.0,M3.5.0/03:00"));
     time_zone_ptr null_tz;
     date d(2003, 12, 20);
     hours h(12);

--- a/test/local_time/testlocal_time_input_facet.cpp
+++ b/test/local_time/testlocal_time_input_facet.cpp
@@ -71,7 +71,7 @@ int main() {
 #if !defined(BOOST_NO_STD_WSTRING)
   {
     std::wstringstream ws;
-    ws.str(L"2005-Feb-15 12:15:00 EST-05EDT,M4.1.0,M10.5.0");
+    ws.str(L"2005-Feb-15 12:15:00 EST+05EDT,M4.1.0,M10.5.0");
     ws >> ldt1;
     check("Wide stream, Eastern US, daylight savings, winter, minimal input",
           ldt1.local_time() == ptime(date(2005,2,15), time_duration(12,15,0)));
@@ -82,7 +82,7 @@ int main() {
     wlocal_time_input_facet* wfacet = new wlocal_time_input_facet(L"%m/%d/%y %ZP");
     std::locale loc(std::locale::classic(), wfacet);
     ws.imbue(loc);
-    ws.str(L"10/31/04 PST-08PDT,M4.1.0,M10.5.0"); // midnight on end transition day, still in dst
+    ws.str(L"10/31/04 PST+08PDT,M4.1.0,M10.5.0"); // midnight on end transition day, still in dst
     ws >> ldt1;
     std::wcout << ldt1.local_time() << std::endl;
     check("Wide stream, Eastern US, daylight savings, winter, custom format",
@@ -94,7 +94,7 @@ int main() {
 #endif // BOOST_NO_STD_WSTRING
 
   std::stringstream ss;
-  ss.str("2005-Feb-25 12:15:00 EST-05EDT,M4.1.0,M10.5.0");
+  ss.str("2005-Feb-25 12:15:00 EST+05EDT,M4.1.0,M10.5.0");
   ss >> ldt1;
   check("Eastern US, daylight savings, winter, minimal input",
         ldt1.local_time() == ptime(date(2005,2,25), time_duration(12,15,0)));
@@ -103,7 +103,7 @@ int main() {
   check("Eastern US, daylight savings, winter, minimal input", !ldt1.is_dst());
   ss.str("");
   
-  ss.str("2005-Aug-25 12:15:00 EST-05EDT,M4.1.0,M10.5.0");
+  ss.str("2005-Aug-25 12:15:00 EST+05EDT,M4.1.0,M10.5.0");
   ss >> ldt1;
   check("Eastern US, daylight savings, summer, minimal input",
         ldt1.local_time() == ptime(date(2005,8,25), time_duration(12,15,0)));
@@ -112,20 +112,20 @@ int main() {
   check("Eastern US, daylight savings, summer, minimal input", ldt1.is_dst());
   ss.str("");
   
-  ss.str("2005-Apr-03 01:15:00 EST-05EDT,M4.1.0,M10.5.0");
+  ss.str("2005-Apr-03 01:15:00 EST+05EDT,M4.1.0,M10.5.0");
   ss >> ldt1;
   check("Eastern US, daylight savings, transition point", !ldt1.is_dst());
   ldt1 += hours(1);
   check("Eastern US, daylight savings, transition point", ldt1.is_dst());
   ss.str("");
-  ss.str("2005-Apr-03 01:15:00 EST-05EDT,93,303");
+  ss.str("2005-Apr-03 01:15:00 EST+05EDT,93,303");
   ss >> ldt1;
   check("Eastern US, daylight savings, transition point", !ldt1.is_dst());
   ldt1 += hours(1);
   check("Eastern US, daylight savings, transition point", ldt1.is_dst());
   ss.str("");
   
-  ss.str("2005-Oct-30 00:15:00 EST-05EDT,M4.1.0,M10.5.0");
+  ss.str("2005-Oct-30 00:15:00 EST+05EDT,M4.1.0,M10.5.0");
   ss >> ldt1;
   check("Eastern US, daylight savings, transition point", ldt1.is_dst());
   ldt1 += hours(1);
@@ -133,7 +133,7 @@ int main() {
   ldt1 += hours(1);
   check("Eastern US, daylight savings, transition point", !ldt1.is_dst());
   ss.str("");
-  ss.str("2005-Oct-30 00:15:00 EST-05EDT,93,303");
+  ss.str("2005-Oct-30 00:15:00 EST+05EDT,93,303");
   ss >> ldt1;
   check("Eastern US, daylight savings, transition point", ldt1.is_dst());
   ldt1 += hours(1);
@@ -142,7 +142,7 @@ int main() {
   check("Eastern US, daylight savings, transition point", !ldt1.is_dst());
   ss.str("");
   
-  ss.str("2005-Aug-25 12:15:00 MST-07");
+  ss.str("2005-Aug-25 12:15:00 MST+07");
   ss >> ldt1;
   check("Mountain US, no daylight savings",
         ldt1.local_time() == ptime(date(2005,8,25), time_duration(12,15,0)));
@@ -156,7 +156,7 @@ int main() {
     new local_time_facet(local_time_input_facet::default_time_input_format);
   std::locale loc(std::locale::classic(), out_facet);
   ss.imbue(loc);
-  time_zone_ptr syd_tz(new posix_time_zone("EST+10EST,M10.5.0,M3.5.0/03:00"));
+  time_zone_ptr syd_tz(new posix_time_zone("EST-10EST,M10.5.0,M3.5.0/03:00"));
   ptime pt(date(2005,6,12), hours(0));
   local_date_time ldt2(pt, syd_tz);
   ss << ldt2;
@@ -166,7 +166,7 @@ int main() {
       ldt1.zone()->dst_local_start_time(2004) == ldt2.zone()->dst_local_start_time(2004));
   ss.str("");
   
-  time_zone_ptr f_tz(new posix_time_zone("FST+03FDT,90,300"));
+  time_zone_ptr f_tz(new posix_time_zone("FST-03FDT,90,300"));
   ldt2 = local_date_time(ptime(date(2005,6,12), hours(0)), f_tz);
   ss << ldt2;
   ss >> ldt1;
@@ -182,7 +182,7 @@ int main() {
   check("Missing time_zone spec makes UTC", ldt1.utc_time() == ldt1.local_time());
   ss.str("");
   {
-    std::istringstream iss("2005-Aug-25 12:15:00 MST-07");
+    std::istringstream iss("2005-Aug-25 12:15:00 MST+07");
     local_time_input_facet* f = new local_time_input_facet("%Y-%b-%d %H:%M:%S %z");
     std::locale loc(std::locale::classic(), f);
     iss.imbue(loc);
@@ -199,39 +199,39 @@ int main() {
   time_label_invalid inv_ex("default");
   check("Failure test ambiguous time label (w/exceptions)", 
         failure_test(ldt1,
-                     "2005-Oct-30 01:15:00 EST-05EDT,M4.1.0,M10.5.0",
+                     "2005-Oct-30 01:15:00 EST+05EDT,M4.1.0,M10.5.0",
                      amb_ex, 
                      new local_time_input_facet()));
   check("Failure test ambiguous time label (no exceptions)", 
         failure_test(ldt1,
-                     "2005-Oct-30 01:15:00 EST-05EDT,M4.1.0,M10.5.0",
+                     "2005-Oct-30 01:15:00 EST+05EDT,M4.1.0,M10.5.0",
                      new local_time_input_facet()));
   check("Failure test ambiguous time label (w/exceptions)", 
         failure_test(ldt1,
-                     "2005-Oct-30 01:15:00 EST-05EDT,93,303",
+                     "2005-Oct-30 01:15:00 EST+05EDT,93,303",
                      amb_ex, 
                      new local_time_input_facet()));
   check("Failure test ambiguous time label (no exceptions)", 
         failure_test(ldt1,
-                     "2005-Oct-30 01:15:00 EST-05EDT,93,303",
+                     "2005-Oct-30 01:15:00 EST+05EDT,93,303",
                      new local_time_input_facet()));
   check("Failure test invalid time label (w/exceptions)", 
         failure_test(ldt1,
-                     "2005-Apr-03 02:15:00 EST-05EDT,M4.1.0,M10.5.0",
+                     "2005-Apr-03 02:15:00 EST+05EDT,M4.1.0,M10.5.0",
                      inv_ex, 
                      new local_time_input_facet()));
   check("Failure test invalid time label (no exceptions)", 
         failure_test(ldt1,
-                     "2005-Apr-03 02:15:00 EST-05EDT,M4.1.0,M10.5.0",
+                     "2005-Apr-03 02:15:00 EST+05EDT,M4.1.0,M10.5.0",
                      new local_time_input_facet()));
   check("Failure test invalid time label (w/exceptions)", 
         failure_test(ldt1,
-                     "2005-Apr-03 02:15:00 EST-05EDT,93,303",
+                     "2005-Apr-03 02:15:00 EST+05EDT,93,303",
                      inv_ex, 
                      new local_time_input_facet()));
   check("Failure test invalid time label (no exceptions)", 
         failure_test(ldt1,
-                     "2005-Apr-03 02:15:00 EST-05EDT,93,303",
+                     "2005-Apr-03 02:15:00 EST+05EDT,93,303",
                      new local_time_input_facet()));
 
 

--- a/test/local_time/testlocal_time_iterator.cpp
+++ b/test/local_time/testlocal_time_iterator.cpp
@@ -41,7 +41,7 @@ int
 main() 
 {
 
-  time_zone_ptr ny_tz(new posix_time_zone("EST-05EDT,M4.1.0,M10.5.0"));
+  time_zone_ptr ny_tz(new posix_time_zone("EST+05EDT,M4.1.0,M10.5.0"));
 
   //set up a time right on the dst boundary -- iterator will 
   //jump forward an hour at the boundary

--- a/test/local_time/testlocal_time_period.cpp
+++ b/test/local_time/testlocal_time_period.cpp
@@ -15,7 +15,7 @@ int main()
   using namespace boost::local_time;
   date d1(2001,Jan, 1);
   
-  time_zone_ptr az_tz(new posix_time_zone("MST-07"));
+  time_zone_ptr az_tz(new posix_time_zone("MST+07"));
 
   local_date_time t1 (d1,hours(2), az_tz, false);//2001-Jan-1 02:00:00
 

--- a/test/local_time/testposix_time_zone.cpp
+++ b/test/local_time/testposix_time_zone.cpp
@@ -19,7 +19,7 @@ int main(){
   using namespace boost::local_time;
   using namespace boost::posix_time;
   using namespace boost::gregorian;
-  std::string specs[] = {"MST-07", "MST-07:00:00","EST-05EDT,M4.1.0,M10.5.0", "EST-05:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00","PST-08PDT,J46/1:30,J310","PST-08PDT,45,310/0:30:00"};
+  std::string specs[] = {"MST+07", "MST+07:00:00","EST+05EDT,M4.1.0,M10.5.0", "EST+05:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00","PST+08PDT,J46/1:30,J310","PST+08PDT,45,310/0:30:00"};
 
   posix_time_zone nyc1(specs[2]);
   posix_time_zone nyc2(specs[3]);
@@ -49,9 +49,9 @@ int main(){
   check("dst ends match", nyc1.dst_local_end_time(2003) == 
       nyc2.dst_local_end_time(2003)); 
   check("to posix string", 
-        nyc1.to_posix_string() == std::string("EST-05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
+        nyc1.to_posix_string() == std::string("EST+05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
   check("to posix string", 
-        nyc2.to_posix_string() == std::string("EST-05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
+        nyc2.to_posix_string() == std::string("EST+05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
   
 
   posix_time_zone az1(specs[0]);
@@ -75,14 +75,14 @@ int main(){
   check("Names", az1.dst_zone_name() == std::string(""));
   check("Names", az2.dst_zone_name() == std::string(""));
   check("to posix string", 
-        az1.to_posix_string() == std::string("MST-07"));
+        az1.to_posix_string() == std::string("MST+07"));
   check("to posix string", 
-        az2.to_posix_string() == std::string("MST-07"));
+        az2.to_posix_string() == std::string("MST+07"));
  
 
   // bizzar time zone spec to fully test parsing
   std::cout << "\nFictitious time zone" << std::endl;
-  posix_time_zone bz("BST+11:21:15BDT-00:28,M2.2.4/03:15:42,M11.5.2/01:08:53");
+  posix_time_zone bz("BST-11:21:15BDT-00:28,M2.2.4/03:15:42,M11.5.2/01:08:53");
   check("hast dst", bz.has_dst());
   check("UTC offset", bz.base_utc_offset() == time_duration(11,21,15));
   check("Abbrev", bz.std_zone_abbrev() == std::string("BST"));
@@ -95,8 +95,8 @@ int main(){
   
   // only checking start & end rules w/ 'J' notation
   std::cout << "\n'J' notation Start/End rule tests..." << std::endl;
-  posix_time_zone la1(specs[4]); // "PST-08PDT,J124,J310"
-  //posix_time_zone la1("PST-08PDT,J1,J365");// Jan1/Dec31 
+  posix_time_zone la1(specs[4]); // "PST+08PDT,J124,J310"
+  //posix_time_zone la1("PST+08PDT,J1,J365");// Jan1/Dec31 
   check("dst start", la1.dst_local_start_time(2003) == 
       ptime(date(2003,Feb,15),time_duration(1,30,0)));
   check("dst end", la1.dst_local_end_time(2003) == 
@@ -109,44 +109,44 @@ int main(){
    * be written in 'n' notation. The reverse is not true so 'n' notation 
    * is used as the output for to_posix_string(). */
   check("to posix string", 
-        la1.to_posix_string() == std::string("PST-08PDT+01,45/01:30,310/02:00"));
+        la1.to_posix_string() == std::string("PST+08PDT+01,45/01:30,310/02:00"));
   
   // only checking start & end rules w/ 'n' notation
   std::cout << "\n'n' notation Start/End rule tests..." << std::endl;
-  posix_time_zone la2(specs[5]); // "PST-08PDT,124,310"
-  //posix_time_zone la2("PST-08PDT,0,365");// Jan1/Dec31 
+  posix_time_zone la2(specs[5]); // "PST+08PDT,124,310"
+  //posix_time_zone la2("PST+08PDT,0,365");// Jan1/Dec31 
   check("dst start", la2.dst_local_start_time(2003) == 
       ptime(date(2003,Feb,15),time_duration(2,0,0)));
   check("dst end", la2.dst_local_end_time(2003) == 
       ptime(date(2003,Nov,6),time_duration(0,30,0)));
   check("to posix string", 
-        la2.to_posix_string() == std::string("PST-08PDT+01,45/02:00,310/00:30"));
+        la2.to_posix_string() == std::string("PST+08PDT+01,45/02:00,310/00:30"));
 
   // bad posix time zone strings tests
   std::cout << "\nInvalid time zone string tests..." << std::endl;
   try {
-    posix_time_zone badz("EST-13");
+    posix_time_zone badz("EST+13");
     check("Exception not thrown: bad UTC offset", false);
   }catch(bad_offset& boff){
     std::string msg(boff.what());
     check("Exception caught: "+msg , true);
   }
   try {
-    posix_time_zone badz("EST-5EDT24:00:01,J124/1:30,J310");
+    posix_time_zone badz("EST+5EDT24:00:01,J124/1:30,J310");
     check("Exception not thrown: bad DST adjust", false);
   }catch(bad_adjustment& badj){
     std::string msg(badj.what());
     check("Exception caught: "+msg , true);
   }
   try {
-    posix_time_zone badz("EST-5EDT01:00:00,J124/-1:30,J310");
+    posix_time_zone badz("EST+5EDT01:00:00,J124/-1:30,J310");
     check("Exception not thrown: bad DST start/end offset", false);
   }catch(bad_offset& boff){
     std::string msg(boff.what());
     check("Exception caught: "+msg , true);
   }
   try {
-    posix_time_zone badz("EST-5EDT01:00:00,J124/1:30,J370");
+    posix_time_zone badz("EST+5EDT01:00:00,J124/1:30,J370");
     check("Exception not thrown: invalid date spec", false);
   }catch(boost::gregorian::bad_day_of_month& boff){
     std::string msg(boff.what());
@@ -163,7 +163,7 @@ int main(){
   //Test a timezone spec on the positive side of the UTC line.
   //This is the time for central europe which is one hour in front of UTC
   //Note these Summer time transition rules aren't actually correct.
-  posix_time_zone cet_tz("CET+01:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
+  posix_time_zone cet_tz("CET-01:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
   check("Has DST", cet_tz.has_dst());
   check("UTC offset", cet_tz.base_utc_offset() == hours(1));
   check("Abbrevs", cet_tz.std_zone_abbrev() == std::string("CET"));
@@ -174,7 +174,7 @@ int main(){
   //Test a timezone spec on the positive side of the UTC line.
   //This is the time for central europe which is one hour in front of UTC
   //Note these Summer time transition rules aren't actually correct.
-  posix_time_zone caus_tz("CAS+08:30:00CDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
+  posix_time_zone caus_tz("CAS-08:30:00CDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
   check("Has DST", caus_tz.has_dst());
   check("UTC offset", caus_tz.base_utc_offset() == hours(8)+minutes(30));
   check("Abbrevs", caus_tz.std_zone_abbrev() == std::string("CAS"));
@@ -183,7 +183,7 @@ int main(){
   {
     /**** first/last of month Julian & non-Julian tests ****/
     // Mar-01 & Oct-31, count begins at 1
-    std::string spec("FST+3FDT,J60,J304"); 
+    std::string spec("FST-3FDT,J60,J304"); 
     posix_time_zone fl_1(spec);
     check("Julian First/last of month", fl_1.dst_local_start_time(2003) == 
         ptime(date(2003,Mar,1),hours(2)));
@@ -195,7 +195,7 @@ int main(){
         ptime(date(2004,Oct,31),hours(2)));
     
     // Mar-01 & Oct-31 Non-leap year, count begins at 0
-    spec = "FST+3FDT,59,304"; // "304" is not a mistake here, see posix_time_zone docs
+    spec = "FST-3FDT,59,304"; // "304" is not a mistake here, see posix_time_zone docs
     posix_time_zone fl_2(spec);
     try{
       check("Non-Julian First/last of month", fl_2.dst_local_start_time(2003) ==
@@ -207,7 +207,7 @@ int main(){
         ptime(date(2003,Oct,31),hours(2)));
     
     // Mar-01 & Oct-31 leap year, count begins at 0
-    spec = "FST+3FDT,60,304"; 
+    spec = "FST-3FDT,60,304"; 
     posix_time_zone fl_3(spec);
     check("Non-Julian First/last of month", fl_3.dst_local_start_time(2004) ==
         ptime(date(2004,Mar,1),hours(2)));

--- a/test/local_time/testtz_database.cpp
+++ b/test/local_time/testtz_database.cpp
@@ -90,7 +90,7 @@ int main(){
   check("az has dst", phx_test->has_dst() == false);
 
   //Now add and retrieve a Posix tz spec from the database
-  time_zone_ptr eastern(new posix_time_zone("EST-05:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00"));
+  time_zone_ptr eastern(new posix_time_zone("EST+05:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00"));
   tz_db.add_record("United States/Eastern", eastern);
   time_zone_ptr eastern_test = tz_db.time_zone_from_region("United States/Eastern");
   check("eastern Valid pointer", eastern_test != time_zone_ptr() );

--- a/test/local_time/testwcustom_time_zone.cpp
+++ b/test/local_time/testwcustom_time_zone.cpp
@@ -67,13 +67,13 @@ main()
         tz1->dst_local_end_time(2003) == ptime(date(2003,Oct,30),hours(2)));
 
   check("tz1 to posix string", 
-       tz1->to_posix_string() == std::wstring(L"PST-08PDT+01,120/02:00,303/02:00"));
+       tz1->to_posix_string() == std::wstring(L"PST+08PDT+01,120/02:00,303/02:00"));
   check("tz2 to posix string", 
-       tz2->to_posix_string() == std::wstring(L"PST-08PDT+01,M4.1.0/02:00,M10.5.0/02:00"));
+       tz2->to_posix_string() == std::wstring(L"PST+08PDT+01,M4.1.0/02:00,M10.5.0/02:00"));
   check("tz3 to posix string", 
-        tz3->to_posix_string() == std::wstring(L"PST-08PDT+01,M3.5.0/02:00,M10.5.0/02:00"));
+        tz3->to_posix_string() == std::wstring(L"PST+08PDT+01,M3.5.0/02:00,M10.5.0/02:00"));
   check("tz4 to posix string", 
-        tz4->to_posix_string() == std::wstring(L"MST-07"));
+        tz4->to_posix_string() == std::wstring(L"MST+07"));
 
   // test start/end for non-dst zone
   check("has dst in non-dst zone", !tz4->has_dst());

--- a/test/local_time/testwposix_time_zone.cpp
+++ b/test/local_time/testwposix_time_zone.cpp
@@ -22,7 +22,7 @@ int main(){
 
   typedef posix_time_zone_base<wchar_t> w_posix_time_zone;
   
-  std::wstring specs[] = {L"MST-07", L"MST-07:00:00",L"EST-05EDT,M4.1.0,M10.5.0", L"EST-05:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00",L"PST-08PDT,J46/1:30,J310",L"PST-08PDT,45,310/0:30:00"};
+  std::wstring specs[] = {L"MST+07", L"MST+07:00:00",L"EST+05EDT,M4.1.0,M10.5.0", L"EST+05:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00",L"PST+08PDT,J46/1:30,J310",L"PST+08PDT,45,310/0:30:00"};
 
   w_posix_time_zone nyc1(specs[2]);
   w_posix_time_zone nyc2(specs[3]);
@@ -52,9 +52,9 @@ int main(){
   check("dst ends match", nyc1.dst_local_end_time(2003) == 
       nyc2.dst_local_end_time(2003)); 
   check("to posix string", 
-        nyc1.to_posix_string() == std::wstring(L"EST-05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
+        nyc1.to_posix_string() == std::wstring(L"EST+05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
   check("to posix string", 
-        nyc2.to_posix_string() == std::wstring(L"EST-05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
+        nyc2.to_posix_string() == std::wstring(L"EST+05EDT+01,M4.1.0/02:00,M10.5.0/02:00"));
   
 
   w_posix_time_zone az1(specs[0]);
@@ -78,14 +78,14 @@ int main(){
   check("Names", az1.dst_zone_name() == std::wstring(L""));
   check("Names", az2.dst_zone_name() == std::wstring(L""));
   check("to posix string", 
-        az1.to_posix_string() == std::wstring(L"MST-07"));
+        az1.to_posix_string() == std::wstring(L"MST+07"));
   check("to posix string", 
-        az2.to_posix_string() == std::wstring(L"MST-07"));
+        az2.to_posix_string() == std::wstring(L"MST+07"));
  
 
   // bizzar time zone spec to fully test parsing
   std::cout << "\nFictitious time zone" << std::endl;
-  w_posix_time_zone bz(L"BST+11:21:15BDT-00:28,M2.2.4/03:15:42,M11.5.2/01:08:53");
+  w_posix_time_zone bz(L"BST-11:21:15BDT-00:28,M2.2.4/03:15:42,M11.5.2/01:08:53");
   check("hast dst", bz.has_dst());
   check("UTC offset", bz.base_utc_offset() == time_duration(11,21,15));
   check("Abbrev", bz.std_zone_abbrev() == std::wstring(L"BST"));
@@ -98,8 +98,8 @@ int main(){
   
   // only checking start & end rules w/ 'J' notation
   std::cout << "\n'J' notation Start/End rule tests..." << std::endl;
-  w_posix_time_zone la1(specs[4]); // "PST-08PDT,J124,J310"
-  //w_posix_time_zone la1("PST-08PDT,J1,J365");// Jan1/Dec31 
+  w_posix_time_zone la1(specs[4]); // "PST+08PDT,J124,J310"
+  //w_posix_time_zone la1("PST+08PDT,J1,J365");// Jan1/Dec31 
   check("dst start", la1.dst_local_start_time(2003) == 
       ptime(date(2003,Feb,15),time_duration(1,30,0)));
   check("dst end", la1.dst_local_end_time(2003) == 
@@ -112,44 +112,44 @@ int main(){
    * be written in 'n' notation. The reverse is not true so 'n' notation 
    * is used as the output for to_posix_string(). */
   check("to posix string", 
-        la1.to_posix_string() == std::wstring(L"PST-08PDT+01,45/01:30,310/02:00"));
+        la1.to_posix_string() == std::wstring(L"PST+08PDT+01,45/01:30,310/02:00"));
   
   // only checking start & end rules w/ 'n' notation
   std::cout << "\n'n' notation Start/End rule tests..." << std::endl;
-  w_posix_time_zone la2(specs[5]); // "PST-08PDT,124,310"
-  //w_posix_time_zone la2("PST-08PDT,0,365");// Jan1/Dec31 
+  w_posix_time_zone la2(specs[5]); // "PST+08PDT,124,310"
+  //w_posix_time_zone la2("PST+08PDT,0,365");// Jan1/Dec31 
   check("dst start", la2.dst_local_start_time(2003) == 
       ptime(date(2003,Feb,15),time_duration(2,0,0)));
   check("dst end", la2.dst_local_end_time(2003) == 
       ptime(date(2003,Nov,6),time_duration(0,30,0)));
   check("to posix string", 
-        la2.to_posix_string() == std::wstring(L"PST-08PDT+01,45/02:00,310/00:30"));
+        la2.to_posix_string() == std::wstring(L"PST+08PDT+01,45/02:00,310/00:30"));
 
   // bad posix time zone strings tests
   std::cout << "\nInvalid time zone string tests..." << std::endl;
   try {
-    w_posix_time_zone badz(L"EST-13");
+    w_posix_time_zone badz(L"EST+13");
     check("Exception not thrown: bad UTC offset", false);
   }catch(bad_offset& boff){
     std::string msg(boff.what());
     check("Exception caught: "+msg , true);
   }
   try {
-    w_posix_time_zone badz(L"EST-5EDT24:00:01,J124/1:30,J310");
+    w_posix_time_zone badz(L"EST+5EDT24:00:01,J124/1:30,J310");
     check("Exception not thrown: bad DST adjust", false);
   }catch(bad_adjustment& badj){
     std::string msg(badj.what());
     check("Exception caught: "+msg , true);
   }
   try {
-    w_posix_time_zone badz(L"EST-5EDT01:00:00,J124/-1:30,J310");
+    w_posix_time_zone badz(L"EST+5EDT01:00:00,J124/-1:30,J310");
     check("Exception not thrown: bad DST start/end offset", false);
   }catch(bad_offset& boff){
     std::string msg(boff.what());
     check("Exception caught: "+msg , true);
   }
   try {
-    w_posix_time_zone badz(L"EST-5EDT01:00:00,J124/1:30,J370");
+    w_posix_time_zone badz(L"EST+5EDT01:00:00,J124/1:30,J370");
     check("Exception not thrown: invalid date spec", false);
   }catch(boost::gregorian::bad_day_of_month& boff){
     std::string msg(boff.what());
@@ -166,7 +166,7 @@ int main(){
   //Test a timezone spec on the positive side of the UTC line.
   //This is the time for central europe which is one hour in front of UTC
   //Note these Summer time transition rules aren't actually correct.
-  w_posix_time_zone cet_tz(L"CET+01:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
+  w_posix_time_zone cet_tz(L"CET-01:00:00EDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
   check("Has DST", cet_tz.has_dst());
   check("UTC offset", cet_tz.base_utc_offset() == hours(1));
   check("Abbrevs", cet_tz.std_zone_abbrev() == std::wstring(L"CET"));
@@ -177,7 +177,7 @@ int main(){
   //Test a timezone spec on the positive side of the UTC line.
   //This is the time for central europe which is one hour in front of UTC
   //Note these Summer time transition rules aren't actually correct.
-  w_posix_time_zone caus_tz(L"CAS+08:30:00CDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
+  w_posix_time_zone caus_tz(L"CAS-08:30:00CDT+01:00:00,M4.1.0/02:00:00,M10.5.0/02:00:00");
   check("Has DST", caus_tz.has_dst());
   check("UTC offset", caus_tz.base_utc_offset() == hours(8)+minutes(30));
   check("Abbrevs", caus_tz.std_zone_abbrev() == std::wstring(L"CAS"));
@@ -186,7 +186,7 @@ int main(){
   {
     /**** first/last of month Julian & non-Julian tests ****/
     // Mar-01 & Oct-31, count begins at 1
-    std::wstring spec(L"FST+3FDT,J60,J304"); 
+    std::wstring spec(L"FST-3FDT,J60,J304"); 
     w_posix_time_zone fl_1(spec);
     check("Julian First/last of month", fl_1.dst_local_start_time(2003) == 
         ptime(date(2003,Mar,1),hours(2)));
@@ -198,7 +198,7 @@ int main(){
         ptime(date(2004,Oct,31),hours(2)));
     
     // Mar-01 & Oct-31 Non-leap year, count begins at 0
-    spec = L"FST+3FDT,59,304"; // "304" is not a mistake here, see posix_time_zone docs
+    spec = L"FST-3FDT,59,304"; // "304" is not a mistake here, see posix_time_zone docs
     w_posix_time_zone fl_2(spec);
     try{
       check("Non-Julian First/last of month", fl_2.dst_local_start_time(2003) ==
@@ -210,7 +210,7 @@ int main(){
         ptime(date(2003,Oct,31),hours(2)));
     
     // Mar-01 & Oct-31 leap year, count begins at 0
-    spec = L"FST+3FDT,60,304"; 
+    spec = L"FST-3FDT,60,304"; 
     w_posix_time_zone fl_3(spec);
     check("Non-Julian First/last of month", fl_3.dst_local_start_time(2004) ==
         ptime(date(2004,Mar,1),hours(2)));

--- a/xmldoc/local_date_time.xml
+++ b/xmldoc/local_date_time.xml
@@ -56,7 +56,7 @@ functions, and IO operators.
   Parameter:
     time_zone_ptr</screen></entry>
             <entry><screen>time_zone_ptr zone(
-  new posix_time_zone("MST-07")
+  new posix_time_zone("MST+07")
 );
 local_date_time ldt = 
   local_microsec_clock::local_time(
@@ -70,7 +70,7 @@ local_date_time ldt =
   Parameter:
     time_zone_ptr</screen></entry>
             <entry><screen>time_zone_ptr zone(
-  new posix_time_zone("MST-07")
+  new posix_time_zone("MST+07")
 );
 local_date_time ldt = 
   local_sec_clock::local_time(zone);</screen>
@@ -121,7 +121,7 @@ local_date_time ldt =
 ptime pt(date(2004,Nov,5), 
          hours(10));
 time_zone_ptr zone(
-  new posix_time_zone("MST-07"));
+  new posix_time_zone("MST+07"));
 local_date_time az(pt, zone);</screen>
             </entry>
           </row>
@@ -138,7 +138,7 @@ local_date_time az(pt, zone);</screen>
           <row>
             <entry><screen>date d(2004,Nov,5);
 time_duration td(5,0,0,0);
-string z("PST-8PDT,M4.1.0,M10.1.0")
+string z("PST+8PDT,M4.1.0,M10.1.0")
 time_zone_ptr zone(
   new posix_time_zone(z));
 local_date_time nyc(d, td, 
@@ -158,7 +158,7 @@ local_date_time nyc(d, td,
           <row>
             <entry><screen>date d(2004,Nov,5);
 time_duration td(5,0,0,0);
-string z("PST-8PDT,M4.1.0,M10.1.0")
+string z("PST+8PDT,M4.1.0,M10.1.0")
 time_zone_ptr zone(
   new posix_time_zone(z));
 local_date_time nyc(d, td, zone, 
@@ -183,7 +183,7 @@ local_date_time nyc(d, td, zone,
           </row>
           <row>
             <entry><screen>time_zone_ptr zone(
-  new posix_time_zone("MST-07")
+  new posix_time_zone("MST+07")
 );
 local_date_time nadt(not_a_date_time, 
                      zone);
@@ -236,7 +236,7 @@ local_date_time nadt(pos_infin);</screen>
             <entry><screen>ptime pt(date(2004,Nov,5), 
          hours(10));
 time_zone_ptr zone(
-  new posix_time_zone("MST-07"));
+  new posix_time_zone("MST+07"));
 local_date_time az(pt, zone);
 az.utc_time(); // 10am 2004-Nov-5</screen>
             </entry>
@@ -250,7 +250,7 @@ az.utc_time(); // 10am 2004-Nov-5</screen>
             <entry><screen>ptime pt(date(2004,Nov,5), 
          hours(10));
 time_zone_ptr zone(
-  new posix_time_zone("MST-07"));
+  new posix_time_zone("MST+07"));
 local_date_time az(pt, zone);
 az.utc_time(); // 10am 2004-Nov-5
 az.local_time(); // 3am 2004-Nov-5</screen></entry>
@@ -333,7 +333,7 @@ ldt.is_not_a_date_time(); // --> true</screen></entry>
             <entry><screen>local_date_time ldt(pos_infin); 
 local_date_time ldt2(not_a_date_time);
 time_zone_ptr 
-  mst(new posix_time_zone("MST-07"));
+  mst(new posix_time_zone("MST+07"));
 local_date_time 
   ldt3(local_sec_clock::local_time(mst));
 ldt.is_special(); // --> true
@@ -366,7 +366,7 @@ ldt3.is_special(); // --> false</screen></entry>
 	</row>
 	<row>
           <entry><screen>
-time_zone_ptr zone(new posix_time_zone("MST-07");
+time_zone_ptr zone(new posix_time_zone("MST+07");
 local_date_time ldt(date(2005,Jul,4),
                     hours(20), 
                     false);
@@ -439,7 +439,7 @@ operator-, operator-=</screen></entry>
 	<row>
           <entry><screen>
 // 6am, 2005-Jul-05 local time
-std::string z("EST-05EDT,M4.1.0,M10.1.0");
+std::string z("EST+05EDT,M4.1.0,M10.1.0");
 ptime pt(date(2005,Jul,5), 
          hours(10));
 time_zone_ptr zone( new posix_time_zone(z));

--- a/xmldoc/local_time.xml
+++ b/xmldoc/local_time.xml
@@ -22,7 +22,7 @@
     The library supports 4 main extensions for the management of local times. This includes 
     <simplelist>
       <member>local_date_time -- locally adjusted time point</member>
-      <member>posix_time_zone -- time zone defined by posix string (eg: "EST10EDT,M10.5.0,M3.5.0/03")</member>
+      <member>posix_time_zone -- time zone defined by posix string (eg: "EST-10EDT,M10.5.0,M3.5.0/03")</member>
       <member>time_zone_database -- get time zones by region from .csv file (eg: America/New York)</member>
       <member>time_zone -- abstract time zone interface</member>
     </simplelist>

--- a/xmldoc/local_time_period.xml
+++ b/xmldoc/local_time_period.xml
@@ -57,7 +57,7 @@ or
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   beg(ptime(date(2005,Jan,1),hours(0)), zone);
 local_date_time 
@@ -76,7 +76,7 @@ local_time_period ltp(beg, end);</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   beg(ptime(date(2005,Jan,1),hours(0)), zone);
 // period for the whole day of 2005-Jan-01
@@ -118,7 +118,7 @@ local_time_period ltp(beg, hours(24));</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   ldt((ptime(date(2005,Jan,1)),hours(0)), zone);
 local_time_period ltp(ldt, hours(2));
@@ -132,7 +132,7 @@ ltp.begin(); // => 2005-Jan-01 00:00:00</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   ldt((ptime(date(2005,Jan,1),hours(0))), zone);
 local_time_period ltp(ldt, hours(2));
@@ -146,7 +146,7 @@ ltp.last(); // => 2005-Jan-01 01:59:59.999999999</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   ldt((ptime(date(2005,Jan,1),hours(0))), zone);
 local_time_period ltp(ldt, hours(2));
@@ -160,7 +160,7 @@ ltp.end(); // => 2005-Jan-01 02:00:00</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   ldt((ptime(date(2005,Jan,1),hours(0))), zone);
 local_time_period ltp(ldt, hours(2));
@@ -174,7 +174,7 @@ ltp.length(); // => 02:00:00</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   beg((ptime(date(2005,Feb,1),hours(0))), zone);
 local_date_time 
@@ -190,7 +190,7 @@ ltp.is_null(); // => true</screen>
 	  </row>
 	  <row>
             <entry><screen>time_zone_ptr 
-  zone(new posix_time_zone("MST-07"));
+  zone(new posix_time_zone("MST+07"));
 local_date_time 
   beg((ptime(date(2005,Jan,1),hours(0))), zone);
 local_date_time 

--- a/xmldoc/posix_time_zone.xml
+++ b/xmldoc/posix_time_zone.xml
@@ -51,17 +51,17 @@
   <para>
     Some examples are:
     <literallayout>
-      "PST-8PDT01:00:00,M4.1.0/02:00:00,M10.1.0/02:00:00"
-      "PST-8PDT,M4.1.0,M10.1.0"</literallayout>These two are actually the same specification (defaults were used in the second string). This zone lies eight hours west of GMT and makes a one hour shift forward during daylight savings time. Daylight savings for this zone starts on the first Sunday of April at 2am, and ends on the first Sunday of October at 2am.
+      "PST+8PDT01:00:00,M4.1.0/02:00:00,M10.1.0/02:00:00"
+      "PST+8PDT,M4.1.0,M10.1.0"</literallayout>These two are actually the same specification (defaults were used in the second string). This zone lies eight hours west of GMT and makes a one hour shift forward during daylight savings time. Daylight savings for this zone starts on the first Sunday of April at 2am, and ends on the first Sunday of October at 2am.
     <literallayout>
-      "MST-7"</literallayout>This zone is as simple as it gets. This zone lies seven hours west of GMT and has no daylight savings.
+      "MST+7"</literallayout>This zone is as simple as it gets. This zone lies seven hours west of GMT and has no daylight savings.
     <literallayout>
-      "EST10EDT,M10.5.0,M3.5.0/03"</literallayout>This string describes the time zone for Sydney Australia. It lies ten hours east of GMT and makes a one hour shift forward during daylight savings. Being located in the southern hemisphere, daylight savings begins on the last Sunday in October at 2am and ends on the last Sunday in March at 3am.
+      "EST-10EDT,M10.5.0,M3.5.0/03"</literallayout>This string describes the time zone for Sydney Australia. It lies ten hours east of GMT and makes a one hour shift forward during daylight savings. Being located in the southern hemisphere, daylight savings begins on the last Sunday in October at 2am and ends on the last Sunday in March at 3am.
     <literallayout>
-      "FST+3FDT02:00,J60/00,J304/02"</literallayout>This specification describes a fictitious zone that lies three hours east of GMT. It makes a two hour shift forward for daylight savings which begins on March 1st at midnight, and ends on October 31st at 2am. The 'J' designation in the start/end specs signifies that counting starts at one and February 29th is never counted.
+      "FST-3FDT02:00,J60/00,J304/02"</literallayout>This specification describes a fictitious zone that lies three hours east of GMT. It makes a two hour shift forward for daylight savings which begins on March 1st at midnight, and ends on October 31st at 2am. The 'J' designation in the start/end specs signifies that counting starts at one and February 29th is never counted.
     <literallayout>
-      "FST+3FDT,59,304"</literallayout>This specification is significant because of the '59'. The lack of 'J' for the start and end dates, indicates that the Julian day-count begins at zero and ends at 365. If you do the math, you'll see that allows for a total of 366 days. This is fine in leap years, but in non-leap years '59' (Feb-29) does not exist. This will construct a valid posix_time_zone object but an exception will be thrown if the date of '59' is accessed in a non-leap year. Ex:
-    <programlisting>posix_time_zone leap_day(std::string("FST+3FDT,59,304"));
+      "FST-3FDT,59,304"</literallayout>This specification is significant because of the '59'. The lack of 'J' for the start and end dates, indicates that the Julian day-count begins at zero and ends at 365. If you do the math, you'll see that allows for a total of 366 days. This is fine in leap years, but in non-leap years '59' (Feb-29) does not exist. This will construct a valid posix_time_zone object but an exception will be thrown if the date of '59' is accessed in a non-leap year. Ex:
+    <programlisting>posix_time_zone leap_day(std::string("FST-3FDT,59,304"));
 leap_day.dst_local_start_time(2004); // ok
 leap_day.dst_local_start_time(2003); // Exception thrown</programlisting>
   </para>
@@ -102,7 +102,7 @@ leap_day.dst_local_start_time(2003); // Exception thrown</programlisting>
         <tbody>
           <row>
             <entry valign="top"><screen>posix_time_zone(std::string)</screen></entry>
-            <entry><screen>std::string nyc("EST-5EDT,M4.1.0,M10.5.0");
+            <entry><screen>std::string nyc("EST+5EDT,M4.1.0,M10.5.0");
 time_zone_ptr zone(new posix_time_zone(nyc));</screen>
             </entry>
           </row>
@@ -211,9 +211,9 @@ time_duration base_utc_offset()</screen></entry>
           </row>
           <row>
             <entry><screen>nyc_zone_sh_ptr-&gt;to_posix_string();
-// "EST-05EDT+01,M4.1.0/02:00,M10.5.0/02:00"
+// "EST+05EDT+01,M4.1.0/02:00,M10.5.0/02:00"
 phx_zone_sh_ptr-&gt;to_posix_string();
-// "MST-07"
+// "MST+07"
             </screen></entry>
           </row>
         </tbody>

--- a/xmldoc/tz_database.xml
+++ b/xmldoc/tz_database.xml
@@ -89,7 +89,7 @@ tz_db.load_from_file("./date_time_zonespec.csv");</screen>
           </row>
           <row>
             <entry><screen>time_zone_ptr zone(
-  new posix_time_zone("PST-8PDT,M4.1.0,M10.1.0")
+  new posix_time_zone("PST+8PDT,M4.1.0,M10.1.0")
 );
 std::string id("America/West_Coast");
 tz_db.add_record(id, zone);</screen>


### PR DESCRIPTION
Currently mistakenly the signs are used the other way around

Fixes:
* https://svn.boost.org/trac/boost/ticket/4545
* https://svn.boost.org/trac/boost/ticket/3336