### PR TITLE
Fix #12040: Order of includes should not matter

### DIFF
--- a/include/boost/date_time/gregorian/greg_serialize.hpp
+++ b/include/boost/date_time/gregorian/greg_serialize.hpp
@@ -2,7 +2,7 @@
 #define GREGORIAN_SERIALIZE_HPP___
 
 /* Copyright (c) 2004-2005 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
@@ -14,7 +14,7 @@
 #include "boost/serialization/split_free.hpp"
 #include "boost/serialization/nvp.hpp"
 
-  
+
 // macros to split serialize functions into save & load functions
 // An expanded version is below for gregorian::date
 // NOTE: these macros define template functions in the boost::serialization namespace.
@@ -43,22 +43,22 @@ namespace serialization {
 
 /*! Method that does serialization for gregorian::date -- splits to load/save
  */
-template<class Archive>                         
-inline void serialize(Archive & ar,                               
+template<class Archive>
+inline void serialize(Archive & ar,
                       ::boost::gregorian::date & d,
                       const unsigned int file_version)
 {
-  split_free(ar, d, file_version);              
-}                                               
+  split_free(ar, d, file_version);
+}
 
 //! Function to save gregorian::date objects using serialization lib
-/*! Dates are serialized into a string for transport and storage. 
+/*! Dates are serialized into a string for transport and storage.
  *  While it would be more efficient to store the internal
- *  integer used to manipulate the dates, it is an unstable solution.  
+ *  integer used to manipulate the dates, it is an unstable solution.
  */
 template<class Archive>
-void save(Archive & ar, 
-          const ::boost::gregorian::date & d, 
+void save(Archive & ar,
+          const ::boost::gregorian::date & d,
           unsigned int /* version */)
 {
   std::string ds = to_iso_string(d);
@@ -66,13 +66,13 @@ void save(Archive & ar,
 }
 
 //! Function to load gregorian::date objects using serialization lib
-/*! Dates are serialized into a string for transport and storage. 
+/*! Dates are serialized into a string for transport and storage.
  *  While it would be more efficient to store the internal
- *  integer used to manipulate the dates, it is an unstable solution.  
+ *  integer used to manipulate the dates, it is an unstable solution.
  */
 template<class Archive>
-void load(Archive & ar, 
-          ::boost::gregorian::date & d, 
+void load(Archive & ar,
+          ::boost::gregorian::date & d,
           unsigned int /*version*/)
 {
   std::string ds;
@@ -93,11 +93,11 @@ void load(Archive & ar,
 
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, 
-                                ::boost::gregorian::date* dp, 
+inline void load_construct_data(Archive & /*ar*/,
+                                ::boost::gregorian::date* dp,
                                 const unsigned int /*file_version*/)
 {
-  // retrieve data from archive required to construct new 
+  // retrieve data from archive required to construct new
   // invoke inplace constructor to initialize instance of date
   ::new(dp) ::boost::gregorian::date(::boost::gregorian::not_a_date_time);
 }
@@ -106,7 +106,7 @@ inline void load_construct_data(Archive & /*ar*/,
 
 //! Function to save gregorian::date_duration objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::date_duration & dd, 
+void save(Archive & ar, const gregorian::date_duration & dd,
           unsigned int /*version*/)
 {
   typename gregorian::date_duration::duration_rep dr = dd.get_rep();
@@ -122,7 +122,7 @@ void load(Archive & ar, gregorian::date_duration & dd, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::date_duration* dd, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::date_duration* dd,
                                 const unsigned int /*file_version*/)
 {
   ::new(dd) gregorian::date_duration(gregorian::not_a_date_time);
@@ -132,7 +132,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::date_duration* dd,
 
 //! helper unction to save date_duration objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::date_duration::duration_rep & dr, 
+void save(Archive & ar, const gregorian::date_duration::duration_rep & dr,
           unsigned int /*version*/)
 {
   typename gregorian::date_duration::duration_rep::int_type it = dr.as_number();
@@ -148,7 +148,7 @@ void load(Archive & ar, gregorian::date_duration::duration_rep & dr, unsigned in
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::date_duration::duration_rep* dr, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::date_duration::duration_rep* dr,
                                 const unsigned int /*file_version*/)
 {
   ::new(dr) gregorian::date_duration::duration_rep(0);
@@ -161,7 +161,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::date_duration::dura
  * the begining date object and the end date object
  */
 template<class Archive>
-void save(Archive & ar, const gregorian::date_period& dp, 
+void save(Archive & ar, const gregorian::date_period& dp,
           unsigned int /*version*/)
 {
   gregorian::date d1 = dp.begin();
@@ -184,7 +184,7 @@ void load(Archive & ar, gregorian::date_period& dp, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::date_period* dp, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::date_period* dp,
                                 const unsigned int /*file_version*/)
 {
   gregorian::date d(gregorian::not_a_date_time);
@@ -196,7 +196,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::date_period* dp,
 
 //! Function to save gregorian::greg_year objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::greg_year& gy, 
+void save(Archive & ar, const gregorian::greg_year& gy,
           unsigned int /*version*/)
 {
   unsigned short us = gy;
@@ -212,7 +212,7 @@ void load(Archive & ar, gregorian::greg_year& gy, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::greg_year* gy, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::greg_year* gy,
                                 const unsigned int /*file_version*/)
 {
   ::new(gy) gregorian::greg_year(1900);
@@ -222,7 +222,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::greg_year* gy,
 
 //! Function to save gregorian::greg_month objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::greg_month& gm, 
+void save(Archive & ar, const gregorian::greg_month& gm,
           unsigned int /*version*/)
 {
   unsigned short us = gm.as_number();
@@ -238,7 +238,7 @@ void load(Archive & ar, gregorian::greg_month& gm, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::greg_month* gm, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::greg_month* gm,
                                 const unsigned int /*file_version*/)
 {
   ::new(gm) gregorian::greg_month(1);
@@ -248,7 +248,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::greg_month* gm,
 
 //! Function to save gregorian::greg_day objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::greg_day& gd, 
+void save(Archive & ar, const gregorian::greg_day& gd,
           unsigned int /*version*/)
 {
   unsigned short us = gd.as_number();
@@ -264,7 +264,7 @@ void load(Archive & ar, gregorian::greg_day& gd, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::greg_day* gd, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::greg_day* gd,
                                 const unsigned int /*file_version*/)
 {
   ::new(gd) gregorian::greg_day(1);
@@ -274,7 +274,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::greg_day* gd,
 
 //! Function to save gregorian::greg_weekday objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::greg_weekday& gd, 
+void save(Archive & ar, const gregorian::greg_weekday& gd,
           unsigned int /*version*/)
 {
   unsigned short us = gd.as_number();
@@ -290,7 +290,7 @@ void load(Archive & ar, gregorian::greg_weekday& gd, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::greg_weekday* gd, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::greg_weekday* gd,
                                 const unsigned int /*file_version*/)
 {
   ::new(gd) gregorian::greg_weekday(1);
@@ -305,7 +305,7 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::greg_weekday* gd,
  * the day (typically greg_day) and month (typically greg_month) objects
  */
 template<class Archive>
-void save(Archive & ar, const gregorian::partial_date& pd, 
+void save(Archive & ar, const gregorian::partial_date& pd,
           unsigned int /*version*/)
 {
   gregorian::greg_day gd(pd.day());
@@ -328,7 +328,7 @@ void load(Archive & ar, gregorian::partial_date& pd, unsigned int /*version*/)
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, gregorian::partial_date* pd, 
+inline void load_construct_data(Archive & /*ar*/, gregorian::partial_date* pd,
                                 const unsigned int /*file_version*/)
 {
   gregorian::greg_month gm(1);
@@ -339,11 +339,11 @@ inline void load_construct_data(Archive & /*ar*/, gregorian::partial_date* pd,
 /**** nth_kday_of_month ****/
 
 //! Function to save nth_day_of_the_week_in_month objects using serialization lib
-/*! nth_day_of_the_week_in_month  objects are broken down into 3 parts for 
+/*! nth_day_of_the_week_in_month  objects are broken down into 3 parts for
  * serialization: the week number, the day of the week, and the month
  */
 template<class Archive>
-void save(Archive & ar, const gregorian::nth_kday_of_month& nkd, 
+void save(Archive & ar, const gregorian::nth_kday_of_month& nkd,
           unsigned int /*version*/)
 {
   typename gregorian::nth_kday_of_month::week_num wn(nkd.nth_week());
@@ -354,7 +354,7 @@ void save(Archive & ar, const gregorian::nth_kday_of_month& nkd,
   ar & make_nvp("nth_kday_of_month_month", m);
 }
 //! Function to load nth_day_of_the_week_in_month objects using serialization lib
-/*! nth_day_of_the_week_in_month  objects are broken down into 3 parts for 
+/*! nth_day_of_the_week_in_month  objects are broken down into 3 parts for
  * serialization: the week number, the day of the week, and the month
  */
 template<class Archive>
@@ -366,13 +366,13 @@ void load(Archive & ar, gregorian::nth_kday_of_month& nkd, unsigned int /*versio
   ar & make_nvp("nth_kday_of_month_week_num", wn);
   ar & make_nvp("nth_kday_of_month_day_of_week", d);
   ar & make_nvp("nth_kday_of_month_month", m);
-  
+
   nkd = gregorian::nth_kday_of_month(wn,d,m);
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, 
-                                gregorian::nth_kday_of_month* nkd, 
+inline void load_construct_data(Archive & /*ar*/,
+                                gregorian::nth_kday_of_month* nkd,
                                 const unsigned int /*file_version*/)
 {
   // values used are not significant
@@ -383,11 +383,11 @@ inline void load_construct_data(Archive & /*ar*/,
 /**** first_kday_of_month ****/
 
 //! Function to save first_day_of_the_week_in_month objects using serialization lib
-/*! first_day_of_the_week_in_month objects are broken down into 2 parts for 
+/*! first_day_of_the_week_in_month objects are broken down into 2 parts for
  * serialization: the day of the week, and the month
  */
 template<class Archive>
-void save(Archive & ar, const gregorian::first_kday_of_month& fkd, 
+void save(Archive & ar, const gregorian::first_kday_of_month& fkd,
           unsigned int /*version*/)
 {
   typename gregorian::first_kday_of_month::day_of_week_type d(fkd.day_of_week().as_number());
@@ -396,7 +396,7 @@ void save(Archive & ar, const gregorian::first_kday_of_month& fkd,
   ar & make_nvp("first_kday_of_month_month", m);
 }
 //! Function to load first_day_of_the_week_in_month objects using serialization lib
-/*! first_day_of_the_week_in_month objects are broken down into 2 parts for 
+/*! first_day_of_the_week_in_month objects are broken down into 2 parts for
  * serialization: the day of the week, and the month
  */
 template<class Archive>
@@ -406,13 +406,13 @@ void load(Archive & ar, gregorian::first_kday_of_month& fkd, unsigned int /*vers
   typename gregorian::first_kday_of_month::month_type m(gregorian::Jan);
   ar & make_nvp("first_kday_of_month_day_of_week", d);
   ar & make_nvp("first_kday_of_month_month", m);
-  
+
   fkd = gregorian::first_kday_of_month(d,m);
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, 
-                                gregorian::first_kday_of_month* fkd, 
+inline void load_construct_data(Archive & /*ar*/,
+                                gregorian::first_kday_of_month* fkd,
                                 const unsigned int /*file_version*/)
 {
   // values used are not significant
@@ -422,11 +422,11 @@ inline void load_construct_data(Archive & /*ar*/,
 /**** last_kday_of_month ****/
 
 //! Function to save last_day_of_the_week_in_month objects using serialization lib
-/*! last_day_of_the_week_in_month objects are broken down into 2 parts for 
+/*! last_day_of_the_week_in_month objects are broken down into 2 parts for
  * serialization: the day of the week, and the month
  */
 template<class Archive>
-void save(Archive & ar, const gregorian::last_kday_of_month& lkd, 
+void save(Archive & ar, const gregorian::last_kday_of_month& lkd,
           unsigned int /*version*/)
 {
   typename gregorian::last_kday_of_month::day_of_week_type d(lkd.day_of_week().as_number());
@@ -435,7 +435,7 @@ void save(Archive & ar, const gregorian::last_kday_of_month& lkd,
   ar & make_nvp("last_kday_of_month_month", m);
 }
 //! Function to load last_day_of_the_week_in_month objects using serialization lib
-/*! last_day_of_the_week_in_month objects are broken down into 2 parts for 
+/*! last_day_of_the_week_in_month objects are broken down into 2 parts for
  * serialization: the day of the week, and the month
  */
 template<class Archive>
@@ -445,13 +445,13 @@ void load(Archive & ar, gregorian::last_kday_of_month& lkd, unsigned int /*versi
   typename gregorian::last_kday_of_month::month_type m(gregorian::Jan);
   ar & make_nvp("last_kday_of_month_day_of_week", d);
   ar & make_nvp("last_kday_of_month_month", m);
-  
+
   lkd = gregorian::last_kday_of_month(d,m);
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, 
-                                gregorian::last_kday_of_month* lkd, 
+inline void load_construct_data(Archive & /*ar*/,
+                                gregorian::last_kday_of_month* lkd,
                                 const unsigned int /*file_version*/)
 {
   // values used are not significant
@@ -462,7 +462,7 @@ inline void load_construct_data(Archive & /*ar*/,
 
 //! Function to save first_day_of_the_week_before objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::first_kday_before& fkdb, 
+void save(Archive & ar, const gregorian::first_kday_before& fkdb,
           unsigned int /*version*/)
 {
   typename gregorian::first_kday_before::day_of_week_type d(fkdb.day_of_week().as_number());
@@ -474,13 +474,13 @@ void load(Archive & ar, gregorian::first_kday_before& fkdb, unsigned int /*versi
 {
   typename gregorian::first_kday_before::day_of_week_type d(gregorian::Monday);
   ar & make_nvp("first_kday_before_day_of_week", d);
-  
+
   fkdb = gregorian::first_kday_before(d);
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, 
-                                gregorian::first_kday_before* fkdb, 
+inline void load_construct_data(Archive & /*ar*/,
+                                gregorian::first_kday_before* fkdb,
                                 const unsigned int /*file_version*/)
 {
   // values used are not significant
@@ -491,7 +491,7 @@ inline void load_construct_data(Archive & /*ar*/,
 
 //! Function to save first_day_of_the_week_after objects using serialization lib
 template<class Archive>
-void save(Archive & ar, const gregorian::first_kday_after& fkda, 
+void save(Archive & ar, const gregorian::first_kday_after& fkda,
           unsigned int /*version*/)
 {
   typename gregorian::first_kday_after::day_of_week_type d(fkda.day_of_week().as_number());
@@ -503,13 +503,13 @@ void load(Archive & ar, gregorian::first_kday_after& fkda, unsigned int /*versio
 {
   typename gregorian::first_kday_after::day_of_week_type d(gregorian::Monday);
   ar & make_nvp("first_kday_after_day_of_week", d);
-  
+
   fkda = gregorian::first_kday_after(d);
 }
 //!override needed b/c no default constructor
 template<class Archive>
-inline void load_construct_data(Archive & /*ar*/, 
-                                gregorian::first_kday_after* fkda, 
+inline void load_construct_data(Archive & /*ar*/,
+                                gregorian::first_kday_after* fkda,
                                 const unsigned int /*file_version*/)
 {
   // values used are not significant

--- a/include/boost/date_time/gregorian/greg_serialize.hpp
+++ b/include/boost/date_time/gregorian/greg_serialize.hpp
@@ -34,6 +34,11 @@ BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::first_kday_before)
 BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::first_kday_after)
 
 namespace boost {
+
+namespace gregorian {
+  std::string to_iso_string(const date&);
+} /* namespace gregorian */
+
 namespace serialization {
 
 /*! Method that does serialization for gregorian::date -- splits to load/save

--- a/test/gregorian/testgreg_serialize.cpp
+++ b/test/gregorian/testgreg_serialize.cpp
@@ -4,7 +4,7 @@
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
  */
- 
+
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
@@ -26,7 +26,7 @@ void save_to(archive_type& ar, const temporal_type& tt)
 
 int main(){
   std::ostringstream oss;
-  
+
   // NOTE: DATE_TIME_XML_SERIALIZE is only used in testing and is
   // defined in the testing Jamfile
 #if defined(DATE_TIME_XML_SERIALIZE)
@@ -36,7 +36,7 @@ int main(){
   std::cout << "Running text archive tests" << std::endl;
   archive::text_oarchive oa(oss);
 #endif
-  
+
   date d(2002,Feb,12);
   date sv_d1(not_a_date_time);
   date sv_d2(pos_infin);
@@ -103,7 +103,7 @@ int main(){
 #else
   archive::text_iarchive ia(iss);
 #endif
-  
+
   // read from the archive
   date d2(not_a_date_time);
   date sv_d3(min_date_time);
@@ -163,7 +163,7 @@ int main(){
     check("Error reading from archive: " + s + "\nWritten data: \"" + oss.str() + "\"", false);
     return printTestStats();
   }
-  
+
   check("date", d == d2);
   check("special_value date (nadt)", sv_d1 == sv_d3);
   check("special_value date (pos_infin)", sv_d2 == sv_d4);

--- a/test/gregorian/testgreg_serialize.cpp
+++ b/test/gregorian/testgreg_serialize.cpp
@@ -10,8 +10,8 @@
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/gregorian/greg_serialize.hpp>
+#include <boost/date_time/gregorian/gregorian.hpp>
 #include "../testfrmwk.hpp"
 #include <sstream>
 


### PR DESCRIPTION
The compilation success of a program should not rely upon the order in which a developer includes the headers. This is unfortunately the case when we want to serialize an object in which one of its member is a boost::gregorian::date.

For the time being, a developer must include <boost/date_time/gregorian/gregorian.hpp> before <boost/date_time/gregorian/grep_serialize.hpp> otherwise the following error is thrown (with gcc, but it is reproduceable in clang):

```
[18:34]stac@macdebian:~/development/cpp-sandbox/boost>g++ --std=c++14 -g -I$HOME/development/date_time/include -lboost_serialization -lboost_date_time serialization.cpp
In file included from serialization.cpp:6:0:
/home/stac/development/date_time/include/boost/date_time/gregorian/greg_serialize.hpp: In function ‘void boost::serialization::save(Archive&, const boost::gregorian::date&, unsigned int)’:
/home/stac/development/date_time/include/boost/date_time/gregorian/greg_serialize.hpp:59:35: error: there are no arguments to ‘to_iso_string’ that depend on a template parameter, so a declaration of ‘to_iso_string’ must be available [-fpermissive]
   std::string ds = to_iso_string(d);
                                   ^
/home/stac/development/date_time/include/boost/date_time/gregorian/greg_serialize.hpp:59:35: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
zsh: exit 1     g++ --std=c++14 -g -I$HOME/development/date_time/include -lboost_serializatio
```

Current architecture: 
Linux macdebian 4.3.0-1-amd64 #1 SMP Debian 4.3.5-1 (2016-02-06) x86_64 GNU/Linux

Compilers:
gcc: g++ (Debian 5.3.1-8) 5.3.1 20160205

clang: Debian clang version 3.6.2-3 (tags/RELEASE_362/final) (based on LLVM 3.6.2) Target: x86_64-pc-linux-gnu Thread model: posix

A solution could be to forward declare the boost::gregorian::to_iso_string(const boost::gregorian::date&) in greg_serialize.hpp. Or to include gregorian/formatters[_limited].hpp

Remark: This problem does not occur with posix_time.
