### PR TITLE
#12180 Avoid dereferencing the input string iterator in the fall-through case.

### DIFF
--- a/include/boost/date_time/time_facet.hpp
+++ b/include/boost/date_time/time_facet.hpp
@@ -1131,9 +1131,10 @@ namespace date_time {
                     if(sec == -1){
                        return check_special_value(sitr, stream_end, t, c);
                     }
-                    if (*itr == 'S')
+                    if (*itr == 'S' || sitr == stream_end)
                       break;
-                    // %s is the same as %S%f so we drop through into %f
+                    // %s is the same as %S%f so we drop through into %f if we are
+                    // not at the end of the stream
                   }
                 case 'f':
                   {


### PR DESCRIPTION
Fixes issue https://svn.boost.org/trac/boost/ticket/12180 by not falling through to the "f" case if the input string does not contain any more characters.