### PR TITLE
Attempt to switch year_month_date() calls to use c++17 struct bind

### DIFF
--- a/example/gregorian/dates_as_strings.cpp
+++ b/example/gregorian/dates_as_strings.cpp
@@ -29,14 +29,24 @@ main()
     std::string ud("20011009"); //2001-Oct-09
     date d1(from_undelimited_string(ud));
     std::cout << to_iso_extended_string(d1) << std::endl;
+
     
     //Output the parts of the date - Tuesday October 9, 2001
-    date::ymd_type ymd = d1.year_month_day();
     greg_weekday wd = d1.day_of_week();
-    std::cout << wd.as_long_string() << " "
-              << ymd.month.as_long_string() << " "
-              << ymd.day << ", " << ymd.year
-              << std::endl;
+    std::cout << wd.as_long_string() << " ";
+
+#ifdef BOOST_NO_CXX17_STRUCT_BIND   // hack not offical
+    date::ymd_type ymd = d1.year_month_day();
+    std::cout << ymd.month.as_long_string() << " "
+      << ymd.day << ", " << ymd.year << std::endl;
+#else
+    // C++17 structured bind
+    auto [yr, mo, dy] = d1.year_month_day();
+    std::cout << mo.as_long_string() << " "
+      << dy << ", " << yr << "\n";
+  
+#endif
+
 
     //Let's send in month 25 by accident and create an exception
     std::string bad_date("20012509"); //2001-??-09

--- a/include/boost/date_time/gregorian/conversion.hpp
+++ b/include/boost/date_time/gregorian/conversion.hpp
@@ -44,10 +44,17 @@ namespace gregorian {
 
     std::tm datetm;
     std::memset(&datetm, 0, sizeof(datetm));
+#ifdef BOOST_NO_CXX17_STRUCT_BIND
     boost::gregorian::date::ymd_type ymd = d.year_month_day();
     datetm.tm_year = ymd.year - 1900;
     datetm.tm_mon = ymd.month - 1;
     datetm.tm_mday = ymd.day;
+#else
+    auto [year, month, day] {d.year_month_day() };
+    datetm.tm_year = year - 1900;
+    datetm.tm_mon = month - 1;
+    datetm.tm_mday = day;
+#endif
     datetm.tm_wday = d.day_of_week();
     datetm.tm_yday = d.day_of_year() - 1;
     datetm.tm_isdst = -1; // negative because not enough info to set tm_isdst

--- a/include/boost/date_time/gregorian/formatters.hpp
+++ b/include/boost/date_time/gregorian/formatters.hpp
@@ -104,14 +104,24 @@ namespace gregorian {
   template<class charT>
   inline std::basic_string<charT> to_sql_string_type(const date& d) 
   {
-    date::ymd_type ymd = d.year_month_day();
     std::basic_ostringstream<charT> ss;
+#ifdef BOOST_NO_CXX17_STRUCT_BIND
+    date::ymd_type ymd = d.year_month_day();
     ss << ymd.year << "-"
        << std::setw(2) << std::setfill(ss.widen('0')) 
        << ymd.month.as_number() //solves problem with gcc 3.1 hanging
        << "-"
        << std::setw(2) << std::setfill(ss.widen('0')) 
        << ymd.day;
+#else
+      auto [year, month, day] {d.year_month_day() };
+      ss << year << "-"
+      << std::setw(2) << std::setfill(ss.widen('0'))
+      << month.as_number() //solves problem with gcc 3.1 hanging
+      << "-"
+      << std::setw(2) << std::setfill(ss.widen('0'))
+      << day;
+#endif
     return ss.str();
   }
   inline std::string to_sql_string(const date& d) {

--- a/include/boost/date_time/gregorian/formatters_limited.hpp
+++ b/include/boost/date_time/gregorian/formatters_limited.hpp
@@ -62,14 +62,24 @@ namespace gregorian {
 
   inline std::string to_sql_string(const date& d) 
   {
-    date::ymd_type ymd = d.year_month_day();
     std::ostringstream ss;
+#ifdef BOOST_NO_CXX17_STRUCT_BIND
+    date::ymd_type ymd = d.year_month_day();
     ss << ymd.year << "-"
        << std::setw(2) << std::setfill('0') 
        << ymd.month.as_number() //solves problem with gcc 3.1 hanging
        << "-"
        << std::setw(2) << std::setfill('0') 
        << ymd.day;
+#else
+      auto [year, month, day] {d.year_month_day() };
+      ss << year << "-"
+      << std::setw(2) << std::setfill('0')
+      << month.as_number() //solves problem with gcc 3.1 hanging
+      << "-"
+      << std::setw(2) << std::setfill('0')
+      << day;
+#endif
     return ss.str();
   }
 

--- a/include/boost/date_time/gregorian/greg_date.hpp
+++ b/include/boost/date_time/gregorian/greg_date.hpp
@@ -119,9 +119,17 @@ namespace gregorian {
     //! Return the last day of the current month
     date end_of_month() const
     {
+#ifdef BOOST_NO_CXX17_STRUCT_BIND   // hack not offical
       ymd_type ymd = year_month_day();
       short eom_day =  gregorian_calendar::end_of_month_day(ymd.year, ymd.month);
       return date(ymd.year, ymd.month, eom_day);
+#else
+      // ideally would like to use something line '_' to ignore
+      auto [year, month, _ignore] {year_month_day () };
+      short eom_day =  gregorian_calendar::end_of_month_day(year, month);
+        
+      return date(year, month, eom_day);
+#endif
     }
 
    private:

--- a/include/boost/date_time/gregorian/greg_month.hpp
+++ b/include/boost/date_time/gregorian/greg_month.hpp
@@ -11,11 +11,16 @@
 
 #include <boost/date_time/constrained_value.hpp>
 #include <boost/date_time/date_defs.hpp>
+#ifdef BOOST_NO_CXX11_SMART_PTR
 #include <boost/shared_ptr.hpp>
+#else
+#   include <memory>
+#endif
 #include <boost/date_time/compiler_config.hpp>
 #include <stdexcept>
 #include <string>
 #include <map>
+
 #include <algorithm>
 #include <cctype>
 
@@ -56,7 +61,11 @@ namespace gregorian {
   public:
     typedef date_time::months_of_year month_enum;
     typedef std::map<std::string, unsigned short> month_map_type;
+#ifdef BOOST_NO_CXX11_SMART_PTR
     typedef boost::shared_ptr<month_map_type> month_map_ptr_type;
+#else
+    using month_map_ptr_type = std::shared_ptr <month_map_type>;
+#endif
     //! Construct a month from the months_of_year enumeration
     greg_month(month_enum theMonth) : 
       greg_month_rep(static_cast<greg_month_rep::value_type>(theMonth)) {}

--- a/xmldoc/date_class.xml
+++ b/xmldoc/date_class.xml
@@ -225,7 +225,13 @@ d.day(); // --> 10</screen></entry>
 date::ymd_type ymd = d.year_month_day();
 // ymd.year  --> 2002, 
 // ymd.month --> 1, 
-// ymd.day   --> 10</screen></entry>
+// ymd.day   --> 10
+      <p>
+// Under C++17
+auto [year, month, day] {d.year_month_day () };
+// year  --> 2002,
+// month --> 1,
+// day   --> 10</screen></entry>
         </row>
         
 	<row>

--- a/xmldoc/ex_dates_as_strings.xml
+++ b/xmldoc/ex_dates_as_strings.xml
@@ -49,12 +49,20 @@
       std::cout << to_iso_extended_string(d1) << std::endl;
       
       //Output the parts of the date - Tuesday October 9, 2001
-      date::ymd_type ymd = d1.year_month_day();
       greg_weekday wd = d1.day_of_week();
-      std::cout << wd.as_long_string() << " "
-                << ymd.month.as_long_string() << " "
-                << ymd.day << ", " << ymd.year
-                << std::endl;
+      std::cout << wd.as_long_string() << " ";
+      
+      #ifdef BOOST_NO_CXX17_STRUCT_BIND   // hack not offical
+      date::ymd_type ymd = d1.year_month_day();
+      std::cout << ymd.month.as_long_string() << " "
+      << ymd.day << ", " << ymd.year << std::endl;
+      #else
+      // C++17 structured bind
+      auto [yr, mo, dy] = d1.year_month_day();
+      std::cout << mo.as_long_string() << " "
+      << dy << ", " << yr << "\n";
+      
+      #endif
 
       //Let's send in month 25 by accident and create an exception
       std::string bad_date("20012509"); //2001-??-09


### PR DESCRIPTION
I made up a Boost macro: BOOST_NO_CXX17_STRUCT_BIND to decide to no use the C++17 feature.