### PR TITLE
Fixed integer overflow when adding many years to a gregorian date.

### DIFF
--- a/include/boost/date_time/adjust_functors.hpp
+++ b/include/boost/date_time/adjust_functors.hpp
@@ -2,7 +2,7 @@
 #define _DATE_TIME_ADJUST_FUNCTORS_HPP___
 
 /* Copyright (c) 2002,2003 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
@@ -14,23 +14,23 @@
 
 namespace boost {
 namespace date_time {
-  
+
 
   //! Functor to iterate a fixed number of days
   template<class date_type>
-  class day_functor 
+  class day_functor
   {
   public:
     typedef typename date_type::duration_type duration_type;
     day_functor(int f) : f_(f) {}
-    duration_type get_offset(const date_type& d) const 
+    duration_type get_offset(const date_type& d) const
     {
       // why is 'd' a parameter???
       // fix compiler warnings
       d.year();
       return duration_type(f_);
     }
-    duration_type get_neg_offset(const date_type& d) const 
+    duration_type get_neg_offset(const date_type& d) const
     {
       // fix compiler warnings
       d.year();
@@ -43,7 +43,7 @@ namespace date_time {
 
   //! Provides calculation to find next nth month given a date
   /*! This adjustment function provides the logic for 'month-based'
-   *  advancement on a ymd based calendar.  The policy it uses 
+   *  advancement on a ymd based calendar.  The policy it uses
    *  to handle the non existant end of month days is to back
    *  up to the last day of the month.  Also, if the starting
    *  date is the last day of a month, this functor will attempt
@@ -51,7 +51,7 @@ namespace date_time {
 
    */
   template<class date_type>
-  class month_functor 
+  class month_functor
   {
   public:
     typedef typename date_type::duration_type duration_type;
@@ -60,7 +60,7 @@ namespace date_time {
     typedef typename cal_type::day_type day_type;
 
     month_functor(int f) : f_(f), origDayOfMonth_(0) {}
-    duration_type get_offset(const date_type& d) const 
+    duration_type get_offset(const date_type& d) const
     {
       ymd_type ymd(d.year_month_day());
       if (origDayOfMonth_ == 0) {
@@ -74,7 +74,7 @@ namespace date_time {
       typedef typename wrap_int2::int_type int_type;
       wrap_int2 wi(ymd.month);
       //calc the year wrap around, add() returns 0 or 1 if wrapped
-      int_type year = wi.add(static_cast<int_type>(f_)); 
+      int_type year = wi.add(f_);
       year = static_cast<int_type>(year + ymd.year); //calculate resulting year
 //       std::cout << "trace wi: " << wi.as_int() << std::endl;
 //       std::cout << "trace year: " << year << std::endl;
@@ -91,7 +91,7 @@ namespace date_time {
       return date_type(year, wi.as_int(), dayOfMonth) - d;
     }
     //! Returns a negative duration_type
-    duration_type get_neg_offset(const date_type& d) const 
+    duration_type get_neg_offset(const date_type& d) const
     {
       ymd_type ymd(d.year_month_day());
       if (origDayOfMonth_ == 0) {
@@ -105,7 +105,7 @@ namespace date_time {
       typedef typename wrap_int2::int_type int_type;
       wrap_int2 wi(ymd.month);
       //calc the year wrap around, add() returns 0 or 1 if wrapped
-      int_type year = wi.subtract(static_cast<int_type>(f_)); 
+      int_type year = wi.subtract(static_cast<int_type>(f_));
       year = static_cast<int_type>(year + ymd.year); //calculate resulting year
       //find the last day for the new month
       day_type resultingEndOfMonthDay(cal_type::end_of_month_day(year, wi.as_int()));
@@ -127,20 +127,20 @@ namespace date_time {
 
   //! Functor to iterate a over weeks
   template<class date_type>
-  class week_functor 
+  class week_functor
   {
   public:
     typedef typename date_type::duration_type duration_type;
     typedef typename date_type::calendar_type calendar_type;
     week_functor(int f) : f_(f) {}
-    duration_type get_offset(const date_type& d) const 
+    duration_type get_offset(const date_type& d) const
     {
       // why is 'd' a parameter???
       // fix compiler warnings
       d.year();
       return duration_type(f_*calendar_type::days_in_week());
     }
-    duration_type get_neg_offset(const date_type& d) const 
+    duration_type get_neg_offset(const date_type& d) const
     {
       // fix compiler warnings
       d.year();
@@ -152,17 +152,17 @@ namespace date_time {
 
   //! Functor to iterate by a year adjusting for leap years
   template<class date_type>
-  class year_functor 
+  class year_functor
   {
   public:
     //typedef typename date_type::year_type year_type;
     typedef typename date_type::duration_type duration_type;
     year_functor(int f) : _mf(f * 12) {}
-    duration_type get_offset(const date_type& d) const 
+    duration_type get_offset(const date_type& d) const
     {
       return _mf.get_offset(d);
     }
-    duration_type get_neg_offset(const date_type& d) const 
+    duration_type get_neg_offset(const date_type& d) const
     {
       return _mf.get_neg_offset(d);
     }
@@ -170,7 +170,7 @@ namespace date_time {
     month_functor<date_type> _mf;
   };
 
-  
+
 } }//namespace date_time
 
 

--- a/include/boost/date_time/gregorian/greg_year.hpp
+++ b/include/boost/date_time/gregorian/greg_year.hpp
@@ -30,10 +30,10 @@ namespace gregorian {
   //! Generated representation for gregorian year
   typedef CV::constrained_value<greg_year_policies> greg_year_rep;
 
-  //! Represent a day of the month (range 1900 - 10000) 
+  //! Represent a year (range 1400 - 10000) 
   /*! This small class allows for simple conversion an integer value into
       a year for the gregorian calendar.  This currently only allows a
-      range of 1900 to 10000.  Both ends of the range are a bit arbitrary
+      range of 1400 to 10000.  Both ends of the range are a bit arbitrary
       at the moment, but they are the limits of current testing of the 
       library.  As such they may be increased in the future.
   */

--- a/test/gregorian/testgreg_durations.cpp
+++ b/test/gregorian/testgreg_durations.cpp
@@ -156,6 +156,15 @@ int main(){
       check("date -= years", date(1994, Feb, 28) == d);
     }
 
+    try {
+      date d1(1500, 6, 1);
+      const date d2 = d1 + years(3000);
+      check("date + many years != overflow", d2 == date(4500, 6, 1));
+    }
+    catch (...) {
+      check("date + many years != overflow", false);
+    }
+
   }
   
   /*** weeks ***/


### PR DESCRIPTION
Also added a testcase to detect the overflow.

Originated from this question: https://stackoverflow.com/questions/45537280/boost-datetime-issue-with-adding-long-year-durations
