### PR TITLE
Fixed integer overflow when subtracting many years to a gregorian date.

### DIFF
--- a/include/boost/date_time/adjust_functors.hpp
+++ b/include/boost/date_time/adjust_functors.hpp
@@ -105,7 +105,7 @@ namespace date_time {
       typedef typename wrap_int2::int_type int_type;
       wrap_int2 wi(ymd.month);
       //calc the year wrap around, add() returns 0 or 1 if wrapped
-      int_type year = wi.subtract(static_cast<int_type>(f_));
+      int_type year = wi.subtract(f_);
       year = static_cast<int_type>(year + ymd.year); //calculate resulting year
       //find the last day for the new month
       day_type resultingEndOfMonthDay(cal_type::end_of_month_day(year, wi.as_int()));

--- a/test/gregorian/testgreg_durations.cpp
+++ b/test/gregorian/testgreg_durations.cpp
@@ -165,6 +165,15 @@ int main(){
       check("date + many years != overflow", false);
     }
 
+    try {
+      date d1(4500, 6, 1);
+      const date d2 = d1 - years(3000);
+      check("date - many years != overflow", d2 == date(1500, 6, 1));
+    }
+    catch (...) {
+      check("date - many years != overflow", false);
+    }
+
   }
   
   /*** weeks ***/


### PR DESCRIPTION
Also added a testcase to detect the overflow.

This is in continuation for https://github.com/boostorg/date_time/pull/41, which fixed the same problem for addition. Sorry I didn't notice the problem with subtraction earlier.
