### PR TITLE
Fix warnings in tests

### DIFF
--- a/test/gregorian/testdate_input_facet.cpp
+++ b/test/gregorian/testdate_input_facet.cpp
@@ -480,7 +480,7 @@ int main(){
     // create date_generator_parser
     typedef boost::date_time::date_generator_parser<date,char> date_gen_parser;
     date_gen_parser dg_parser("Zuerst","Zweitens","Dritt","Viert",
-                              "Fünft","Letzt","Vor","Nach","Von");
+                              "F\xC3\xBCnft","Letzt","Vor","Nach","Von");
 
     // create the date_input_facet
     date_input_facet* de_facet =

--- a/test/gregorian/testparse_date.cpp
+++ b/test/gregorian/testparse_date.cpp
@@ -345,6 +345,7 @@ main()
     std::string ud(""); //empty string error sf bug# 1155556
     date d1(from_simple_string(ud));
     check("empty string",  false); //should never reach this piont
+    (void)d1;
   }
   catch(std::exception& e) {
     check(std::string("empty string parse (exception expected): ") + e.what(),  true);

--- a/test/testfrmwk.hpp
+++ b/test/testfrmwk.hpp
@@ -57,15 +57,15 @@ inline bool check(const std::string& testname, bool testcond)
 }
 
 // In the comparisons below, it is possible that T and U are signed and unsigned integer types, which generates warnings in some compilers.
-#if defined(_MSC_VER)
+#if defined(BOOST_MSVC)
 # pragma warning(push)
 # pragma warning(disable: 4389)
-#elif defined(__clang__) && defined(__has_warning)
+#elif defined(BOOST_CLANG) && defined(__has_warning)
 # if __has_warning("-Wsign-compare")
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wsign-compare"
 # endif
-#elif defined(__GNUC__) && !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 406
+#elif defined(BOOST_GCC) && (BOOST_GCC+0) >= 40600
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
@@ -81,13 +81,13 @@ inline bool check_equal(const std::string& testname, T const& left, U const& rig
   return res;
 }
 
-#if defined(_MSC_VER)
+#if defined(BOOST_MSVC)
 # pragma warning(pop)
-#elif defined(__clang__) && defined(__has_warning)
+#elif defined(BOOST_CLANG) && defined(__has_warning)
 # if __has_warning("-Wsign-compare")
 #  pragma clang diagnostic pop
 # endif
-#elif defined(__GNUC__) && !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 406
+#elif defined(BOOST_GCC) && (BOOST_GCC+0) >= 40600
 # pragma GCC diagnostic pop
 #endif
 

--- a/test/testfrmwk.hpp
+++ b/test/testfrmwk.hpp
@@ -56,6 +56,20 @@ inline bool check(const std::string& testname, bool testcond)
   }
 }
 
+// In the comparisons below, it is possible that T and U are signed and unsigned integer types, which generates warnings in some compilers.
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4389)
+#elif defined(__clang__) && defined(__has_warning)
+# if __has_warning("-Wsign-compare")
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wsign-compare"
+# endif
+#elif defined(__GNUC__) && !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 406
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 template< typename T, typename U >
 inline bool check_equal(const std::string& testname, T const& left, U const& right)
 {
@@ -66,6 +80,16 @@ inline bool check_equal(const std::string& testname, T const& left, U const& rig
   }
   return res;
 }
+
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#elif defined(__clang__) && defined(__has_warning)
+# if __has_warning("-Wsign-compare")
+#  pragma clang diagnostic pop
+# endif
+#elif defined(__GNUC__) && !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 406
+# pragma GCC diagnostic pop
+#endif
 
 #ifndef BOOST_NO_STD_WSTRING
 inline bool check_equal(const std::string& testname, std::wstring const& left, std::wstring const& right)


### PR DESCRIPTION
- Fixes "invalid character" warnings by clang.
- Fixes "signed/unsigned mismatch" in comparisons by gcc.
- Fixes "unused variable" warning from clang.

All warnings are specific for tests; no library code affected.
