### PR TITLE
Port to Boost.WinAPI and cleanup warnings

### DIFF
--- a/include/boost/date_time/filetime_functions.hpp
+++ b/include/boost/date_time/filetime_functions.hpp
@@ -19,10 +19,6 @@
 
 #if defined(BOOST_HAS_FTIME) // skip this file if no FILETIME
 
-#if defined(BOOST_USE_WINDOWS_H)
-#  include <windows.h>
-#endif
-
 #include <boost/cstdint.hpp>
 #include <boost/date_time/time.hpp>
 #include <boost/date_time/date_defs.hpp>
@@ -30,85 +26,6 @@
 namespace boost {
 
 namespace date_time {
-
-namespace winapi {
-
-#if !defined(BOOST_USE_WINDOWS_H)
-
-    extern "C" {
-
-        struct FILETIME
-        {
-            boost::uint32_t dwLowDateTime;
-            boost::uint32_t dwHighDateTime;
-        };
-        struct SYSTEMTIME
-        {
-            boost::uint16_t wYear;
-            boost::uint16_t wMonth;
-            boost::uint16_t wDayOfWeek;
-            boost::uint16_t wDay;
-            boost::uint16_t wHour;
-            boost::uint16_t wMinute;
-            boost::uint16_t wSecond;
-            boost::uint16_t wMilliseconds;
-        };
-
-        __declspec(dllimport) void __stdcall GetSystemTimeAsFileTime(FILETIME* lpFileTime);
-        __declspec(dllimport) int __stdcall FileTimeToLocalFileTime(const FILETIME* lpFileTime, FILETIME* lpLocalFileTime);
-        __declspec(dllimport) void __stdcall GetSystemTime(SYSTEMTIME* lpSystemTime);
-        __declspec(dllimport) int __stdcall SystemTimeToFileTime(const SYSTEMTIME* lpSystemTime, FILETIME* lpFileTime);
-
-    } // extern "C"
-
-#endif // defined(BOOST_USE_WINDOWS_H)
-
-    typedef FILETIME file_time;
-    typedef SYSTEMTIME system_time;
-
-    inline void get_system_time_as_file_time(file_time& ft)
-    {
-#if BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3205))
-        // Some runtime library implementations expect local times as the norm for ctime.
-        file_time ft_utc;
-        GetSystemTimeAsFileTime(&ft_utc);
-        FileTimeToLocalFileTime(&ft_utc, &ft);
-#elif defined(BOOST_HAS_GETSYSTEMTIMEASFILETIME)
-        GetSystemTimeAsFileTime(&ft);
-#else
-        system_time st;
-        GetSystemTime(&st);
-        SystemTimeToFileTime(&st, &ft);
-#endif
-    }
-
-    /*!
-     * The function converts file_time into number of microseconds elapsed since 1970-Jan-01
-     *
-     * \note Only dates after 1970-Jan-01 are supported. Dates before will be wrapped.
-     *
-     * \note The function is templated on the FILETIME type, so that
-     *       it can be used with both native FILETIME and the ad-hoc
-     *       boost::date_time::winapi::file_time type.
-     */
-    template< typename FileTimeT >
-    inline boost::uint64_t file_time_to_microseconds(FileTimeT const& ft)
-    {
-        /* shift is difference between 1970-Jan-01 & 1601-Jan-01
-        * in 100-nanosecond intervals */
-        const uint64_t shift = 116444736000000000ULL; // (27111902 << 32) + 3577643008
-
-        union {
-            FileTimeT as_file_time;
-            uint64_t as_integer; // 100-nanos since 1601-Jan-01
-        } caster;
-        caster.as_file_time = ft;
-
-        caster.as_integer -= shift; // filetime is now 100-nanos since 1970-Jan-01
-        return (caster.as_integer / 10); // truncate to microseconds
-    }
-
-} // namespace winapi
 
 //! Create a time object from an initialized FILETIME struct.
 /*!
@@ -119,7 +36,7 @@ namespace winapi {
  *
  * \note The function is templated on the FILETIME type, so that
  *       it can be used with both native FILETIME and the ad-hoc
- *       boost::date_time::winapi::file_time type.
+ *       boost::detail::winapi::FILETIME_ type.
  */
 template< typename TimeT, typename FileTimeT >
 inline
@@ -132,16 +49,13 @@ TimeT time_from_ftime(const FileTimeT& ft)
     // https://svn.boost.org/trac/boost/ticket/2523
     // Since this function can be called with arbitrary times, including ones that
     // are before 1970-Jan-01, we'll have to cast the time a bit differently,
-    // than it is done in the file_time_to_microseconds function. This allows to
+    // than it is done in the microsec_clock::file_time_to_microseconds function. This allows to
     // avoid integer wrapping for dates before 1970-Jan-01.
-    union {
-        FileTimeT as_file_time;
-        uint64_t as_integer; // 100-nanos since 1601-Jan-01
-    } caster;
-    caster.as_file_time = ft;
 
-    uint64_t sec = caster.as_integer / 10000000UL;
-    uint32_t sub_sec = (caster.as_integer % 10000000UL) // 100-nanoseconds since the last second
+    // 100-nanos since 1601-Jan-01
+    uint64_t ft_as_integer = (static_cast< uint64_t >(ft.dwHighDateTime) << 32) | static_cast< uint64_t >(ft.dwLowDateTime);
+    uint64_t sec = ft_as_integer / 10000000UL;
+    uint32_t sub_sec = (ft_as_integer % 10000000UL) // 100-nanoseconds since the last second
 #if !defined(BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG)
         / 10; // microseconds since the last second
 #else

--- a/include/boost/date_time/filetime_functions.hpp
+++ b/include/boost/date_time/filetime_functions.hpp
@@ -55,11 +55,11 @@ TimeT time_from_ftime(const FileTimeT& ft)
     // 100-nanos since 1601-Jan-01
     uint64_t ft_as_integer = (static_cast< uint64_t >(ft.dwHighDateTime) << 32) | static_cast< uint64_t >(ft.dwLowDateTime);
     uint64_t sec = ft_as_integer / 10000000UL;
-    uint32_t sub_sec = (ft_as_integer % 10000000UL) // 100-nanoseconds since the last second
+    uint32_t sub_sec = static_cast< uint32_t >(ft_as_integer % 10000000UL) // 100-nanoseconds since the last second
 #if !defined(BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG)
-        / 10; // microseconds since the last second
+        / 10U; // microseconds since the last second
 #else
-        * 100; // nanoseconds since the last second
+        * 100U; // nanoseconds since the last second
 #endif
 
     // split sec into usable chunks: days, hours, minutes, & seconds

--- a/include/boost/date_time/microsec_time_clock.hpp
+++ b/include/boost/date_time/microsec_time_clock.hpp
@@ -135,15 +135,15 @@ namespace date_time {
      */
     static boost::uint64_t file_time_to_microseconds(boost::detail::winapi::FILETIME_ const& ft)
     {
-        // shift is difference between 1970-Jan-01 & 1601-Jan-01
-        // in 100-nanosecond units
-        const boost::uint64_t shift = 116444736000000000ULL; // (27111902 << 32) + 3577643008
+      // shift is difference between 1970-Jan-01 & 1601-Jan-01
+      // in 100-nanosecond units
+      const boost::uint64_t shift = 116444736000000000ULL; // (27111902 << 32) + 3577643008
 
-        // 100-nanos since 1601-Jan-01
-        boost::uint64_t ft_as_integer = (static_cast< boost::uint64_t >(ft.dwHighDateTime) << 32) | static_cast< boost::uint64_t >(ft.dwLowDateTime);
+      // 100-nanos since 1601-Jan-01
+      boost::uint64_t ft_as_integer = (static_cast< boost::uint64_t >(ft.dwHighDateTime) << 32) | static_cast< boost::uint64_t >(ft.dwLowDateTime);
 
-        ft_as_integer -= shift; // filetime is now 100-nanos since 1970-Jan-01
-        return (ft_as_integer / 10U); // truncate to microseconds
+      ft_as_integer -= shift; // filetime is now 100-nanos since 1970-Jan-01
+      return (ft_as_integer / 10U); // truncate to microseconds
     }
 #endif
   };

--- a/include/boost/date_time/microsec_time_clock.hpp
+++ b/include/boost/date_time/microsec_time_clock.hpp
@@ -20,7 +20,9 @@
 #include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/c_time.hpp>
 #include <boost/date_time/time_clock.hpp>
-#include <boost/date_time/filetime_functions.hpp>
+#if defined(BOOST_HAS_FTIME)
+#include <boost/detail/winapi/time.hpp>
+#endif
 
 #ifdef BOOST_DATE_TIME_HAS_HIGH_PRECISION_CLOCK
 
@@ -85,10 +87,19 @@ namespace date_time {
       std::time_t t = tv.tv_sec;
       boost::uint32_t sub_sec = tv.tv_usec;
 #elif defined(BOOST_HAS_FTIME)
-      winapi::file_time ft;
-      winapi::get_system_time_as_file_time(ft);
-      uint64_t micros = winapi::file_time_to_microseconds(ft); // it will not wrap, since ft is the current time
-                                                               // and cannot be before 1970-Jan-01
+      boost::detail::winapi::FILETIME_ ft;
+      boost::detail::winapi::GetSystemTimeAsFileTime(&ft);
+#if BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3205))
+      // Some runtime library implementations expect local times as the norm for ctime functions.
+      {
+        boost::detail::winapi::FILETIME_ local_ft;
+        boost::detail::winapi::FileTimeToLocalFileTime(&ft, &local_ft);
+        ft = local_ft;
+      }
+#endif
+
+      boost::uint64_t micros = file_time_to_microseconds(ft); // it will not wrap, since ft is the current time
+                                                              // and cannot be before 1970-Jan-01
       std::time_t t = static_cast<std::time_t>(micros / 1000000UL); // seconds since epoch
       // microseconds -- static casts suppress warnings
       boost::uint32_t sub_sec = static_cast<boost::uint32_t>(micros % 1000000UL);
@@ -115,6 +126,26 @@ namespace date_time {
 
       return time_type(d,td);
     }
+
+#if defined(BOOST_HAS_FTIME)
+    /*!
+     * The function converts file_time into number of microseconds elapsed since 1970-Jan-01
+     *
+     * \note Only dates after 1970-Jan-01 are supported. Dates before will be wrapped.
+     */
+    static boost::uint64_t file_time_to_microseconds(boost::detail::winapi::FILETIME_ const& ft)
+    {
+        // shift is difference between 1970-Jan-01 & 1601-Jan-01
+        // in 100-nanosecond units
+        const boost::uint64_t shift = 116444736000000000ULL; // (27111902 << 32) + 3577643008
+
+        // 100-nanos since 1601-Jan-01
+        boost::uint64_t ft_as_integer = (static_cast< boost::uint64_t >(ft.dwHighDateTime) << 32) | static_cast< boost::uint64_t >(ft.dwLowDateTime);
+
+        ft_as_integer -= shift; // filetime is now 100-nanos since 1970-Jan-01
+        return (ft_as_integer / 10U); // truncate to microseconds
+    }
+#endif
   };
 
 

--- a/include/boost/date_time/posix_time/conversion.hpp
+++ b/include/boost/date_time/posix_time/conversion.hpp
@@ -80,7 +80,7 @@ namespace posix_time {
    *
    * \note The function is templated on the FILETIME type, so that
    *       it can be used with both native FILETIME and the ad-hoc
-   *       boost::date_time::winapi::file_time type.
+   *       boost::detail::winapi::FILETIME_ type.
    */
   template< typename TimeT, typename FileTimeT >
   inline

--- a/test/gregorian/testdate.cpp
+++ b/test/gregorian/testdate.cpp
@@ -286,7 +286,7 @@ main()
     tm d_tm = to_tm(d);
     check("Exception not thrown (special_value to_tm)", false);
     std::cout << d_tm.tm_sec << std::endl; //does nothing useful but stops compiler from complaining about unused d_tm
-  }catch(std::out_of_range& e){
+  }catch(std::out_of_range&){
     check("Caught expected exception (special_value to_tm)", true);
   }catch(...){
     check("Caught un-expected exception (special_value to_tm)", false);

--- a/test/gregorian/testparse_date.cpp
+++ b/test/gregorian/testparse_date.cpp
@@ -89,7 +89,7 @@ main()
         check("Expected exception not thrown: from ISO string (bad_day_of_month)", false);
         std::cout << date_from_iso_string(s) << std::endl;
       }
-      catch(bad_day_of_month& e) {
+      catch(bad_day_of_month&) {
         check("Caught expected exception: bad_day_of_month ", true);
       }
       catch(...) {

--- a/test/local_time/testlocal_time.cpp
+++ b/test/local_time/testlocal_time.cpp
@@ -290,7 +290,7 @@ main()
         check("Exception not thrown (special_value to_tm)", false);
 	//does nothing useful but stops compiler from complaining about unused ldt_tm
 	std::cout << ldt_tm.tm_sec << std::endl; 
-      }catch(std::out_of_range& e){
+      }catch(std::out_of_range&){
         check("Caught expected exception (special_value to_tm)", true);
       }catch(...){
         check("Caught un-expected exception (special_value to_tm)", false);

--- a/test/local_time/testlocal_time_facet.cpp
+++ b/test/local_time/testlocal_time_facet.cpp
@@ -49,7 +49,7 @@ int main(){
     // first try to find the data file from the test dir
     time_zones.load_from_file("../data/date_time_zonespec.csv");
   }
-  catch(const data_not_accessible& e) {
+  catch(const data_not_accessible&) {
     // couldn't find the data file so assume we are being run from 
     // boost_root/status and try again
     try {

--- a/test/local_time/testposix_time_zone.cpp
+++ b/test/local_time/testposix_time_zone.cpp
@@ -200,7 +200,7 @@ int main(){
     try{
       check("Non-Julian First/last of month", fl_2.dst_local_start_time(2003) ==
           ptime(date(2003,Mar,1),hours(2)));
-    }catch(std::exception& e){
+    }catch(std::exception&){
       check("Expected exception caught for Non-Julian day of 59, in non-leap year (Feb-29)", true);
     }
     check("Non-Julian First/last of month", fl_2.dst_local_end_time(2003) == 

--- a/test/local_time/testtz_database.cpp
+++ b/test/local_time/testtz_database.cpp
@@ -32,7 +32,7 @@ int main(){
   try{
     tz_database tz_db;
     tz_db.load_from_file("missing_file.csv"); // file does not exist
-  }catch(data_not_accessible& e){
+  }catch(data_not_accessible&){
     check("Caught Missing data file exception", true);
   }catch(...){
     check("Caught first unexpected exception", false);
@@ -52,7 +52,7 @@ int main(){
   try {
     // first try to find the data file from the test dir
     tz_db.load_from_file("../data/date_time_zonespec.csv");
-  }catch(data_not_accessible& e) {
+  }catch(data_not_accessible&) {
     // couldn't find the data file so assume we are being run from 
     // boost_root/status and try again
     tz_db.load_from_file("../libs/date_time/data/date_time_zonespec.csv");
@@ -121,14 +121,14 @@ bool run_bad_field_count_test()
   tz_database other_db;
   try{
     other_db.load_from_file("local_time/poorly_formed_zonespec.csv");
-  }catch(bad_field_count& be){
+  }catch(bad_field_count&){
     caught_bfc = true;
   }catch(...) {
     // do nothing (file not found)
   }
   try{
     other_db.load_from_file("../libs/date_time/test/local_time/poorly_formed_zonespec.csv");
-  }catch(bad_field_count& be){
+  }catch(bad_field_count&){
     caught_bfc = true;
   }catch(...) {
     // do nothing (file not found)

--- a/test/local_time/testwposix_time_zone.cpp
+++ b/test/local_time/testwposix_time_zone.cpp
@@ -203,7 +203,7 @@ int main(){
     try{
       check("Non-Julian First/last of month", fl_2.dst_local_start_time(2003) ==
           ptime(date(2003,Mar,1),hours(2)));
-    }catch(std::exception& e){
+    }catch(std::exception&){
       check("Expected exception caught for Non-Julian day of 59, in non-leap year (Feb-29)", true);
     }
     check("Non-Julian First/last of month", fl_2.dst_local_end_time(2003) == 

--- a/test/posix_time/testfiletime_functions.cpp
+++ b/test/posix_time/testfiletime_functions.cpp
@@ -22,7 +22,7 @@ int main()
 
   // adjustor is used to truncate ptime's fractional seconds for 
   // comparison with SYSTEMTIME's milliseconds
-  const int adjustor = time_duration::ticks_per_second() / 1000;
+  const time_duration::tick_type adjustor = time_duration::ticks_per_second() / 1000;
   
   for(int i = 0; i < 5; ++i){
 

--- a/test/posix_time/testtime.cpp
+++ b/test/posix_time/testtime.cpp
@@ -309,7 +309,7 @@ main()
     check("Exception not thrown (special_value to_tm)", false);
     //following code does nothing useful but stops compiler from complaining about unused pt_tm
     std::cout << pt_tm.tm_sec << std::endl;
-  }catch(std::out_of_range& e){
+  }catch(std::out_of_range&){
     check("Caught expected exception (special_value to_tm)", true);
   }catch(...){
     check("Caught un-expected exception (special_value to_tm)", false);
@@ -323,7 +323,7 @@ main()
     check("Exception not thrown (special_value to_tm)", false);
     //following code does nothing useful but stops compiler from complaining about unused pt_tm
     std::cout << pt_tm.tm_sec << std::endl;
-  }catch(std::out_of_range& e){
+  }catch(std::out_of_range&){
     check("Caught expected exception (special_value to_tm)", true);
   }catch(...){
     check("Caught un-expected exception (special_value to_tm)", false);


### PR DESCRIPTION
This PR ports Boost.DateTime to Boost.WinAPI for Windows-specific timing functions. This should resolve compilation issues with clang/gcc, where Windows SDK declares functions differently than Boost.DateTime.

This PR also silences a few warnings about unused variables and possible integer truncation in tests.
