### PR TITLE
Add more robust integer overflow handling in month offset algorithms.

### DIFF
--- a/include/boost/date_time/adjust_functors.hpp
+++ b/include/boost/date_time/adjust_functors.hpp
@@ -9,12 +9,39 @@
  * $Date$
  */
 
-#include "boost/date_time/date.hpp"
-#include "boost/date_time/wrapping_int.hpp"
+#include <limits>
+#include <boost/cstdint.hpp>
+#include <boost/integer.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/type_traits/common_type.hpp>
+#include <boost/type_traits/is_unsigned.hpp>
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/date.hpp>
+#include <boost/date_time/wrapping_int.hpp>
+#include <boost/date_time/special_defs.hpp>
 
 namespace boost {
 namespace date_time {
+namespace detail {
 
+// The type trait promotes an unsigned integer type to the nearest larger
+// signed integer type that can encompass all values of the original type
+template< typename T, bool HasLargerType = (sizeof(T) < sizeof(boost::uintmax_t)) >
+struct promote_to_signed
+{
+  typedef typename boost::int_t< std::numeric_limits< T >::digits * 2 >::exact type;
+};
+
+// This specialization is the best we can do if T cannot be promoted. Integer
+// overflow can happen in this case.
+template< typename T >
+struct promote_to_signed< T, false >
+{
+  typedef boost::intmax_t type;
+};
+
+} // namespace detail
 
   //! Functor to iterate a fixed number of days
   template<class date_type>
@@ -54,12 +81,27 @@ namespace date_time {
   class month_functor
   {
   public:
+    typedef int difference_type;
     typedef typename date_type::duration_type duration_type;
     typedef typename date_type::calendar_type cal_type;
     typedef typename cal_type::ymd_type ymd_type;
     typedef typename cal_type::day_type day_type;
+    typedef typename cal_type::month_type month_type;
+    typedef typename cal_type::year_type year_type;
 
-    month_functor(int f) : f_(f), origDayOfMonth_(0) {}
+  private:
+    typedef typename year_type::value_policy year_value_policy;
+    typedef typename year_value_policy::value_type year_rep_type;
+    typedef typename mpl::eval_if<
+      is_unsigned<year_rep_type>,
+      date_time::detail::promote_to_signed<year_rep_type>,
+      mpl::identity<year_rep_type>
+    >::type signed_year_rep_type;
+    typedef typename boost::common_type<difference_type, signed_year_rep_type>::type year_common_type;
+    typedef date_time::wrapping_int2<typename month_type::value_type,1,12> month_wrapping_int;
+
+  public:
+    month_functor(difference_type f) : f_(f), origDayOfMonth_(0) {}
     duration_type get_offset(const date_type& d) const
     {
       ymd_type ymd(d.year_month_day());
@@ -70,25 +112,34 @@ namespace date_time {
           origDayOfMonth_ = -1; //force the value to the end of month
         }
       }
-      typedef date_time::wrapping_int2<short,1,12> wrap_int2;
-      typedef typename wrap_int2::int_type int_type;
-      wrap_int2 wi(ymd.month);
-      //calc the year wrap around, add() returns 0 or 1 if wrapped
-      int_type year = static_cast<int_type>(wi.add(f_));
-      year = static_cast<int_type>(year + ymd.year); //calculate resulting year
-//       std::cout << "trace wi: " << wi.as_int() << std::endl;
-//       std::cout << "trace year: " << year << std::endl;
+      month_wrapping_int wi(ymd.month);
+      //calc the year wrap around, add() returns the number of wraps
+      year_common_type year_offset = wi.add(static_cast< year_common_type >(f_));
+      year_common_type year = year_offset + ymd.year; //calculate resulting year
+      // We have to mimic the similar checks in constrained_value here because
+      // the year value may exceed the range of year_rep_type and get truncated
+      // when passed to the year_type constructor. By performing the checks on the full-sized
+      // integers here we avoid integer overflow.
+      if (BOOST_UNLIKELY(year + 1 < static_cast< year_common_type >((year_value_policy::min)() + 1))) {
+        year_value_policy::on_error(ymd.year, static_cast< year_rep_type >(year_offset), CV::min_violation);
+        return duration_type(not_a_date_time);
+      }
+      if (BOOST_UNLIKELY(year > static_cast< year_common_type >((year_value_policy::max)()))) {
+        year_value_policy::on_error(ymd.year, static_cast< year_rep_type >(year_offset), CV::max_violation);
+        return duration_type(not_a_date_time);
+      }
+
       //find the last day for the new month
-      day_type resultingEndOfMonthDay(cal_type::end_of_month_day(year, wi.as_int()));
+      day_type resultingEndOfMonthDay(cal_type::end_of_month_day(static_cast< year_rep_type >(year), wi.as_int()));
       //original was the end of month -- force to last day of month
       if (origDayOfMonth_ == -1) {
-        return date_type(year, wi.as_int(), resultingEndOfMonthDay) - d;
+        return date_type(static_cast< year_rep_type >(year), wi.as_int(), resultingEndOfMonthDay) - d;
       }
       day_type dayOfMonth = origDayOfMonth_;
       if (dayOfMonth > resultingEndOfMonthDay) {
         dayOfMonth = resultingEndOfMonthDay;
       }
-      return date_type(year, wi.as_int(), dayOfMonth) - d;
+      return date_type(static_cast< year_rep_type >(year), wi.as_int(), dayOfMonth) - d;
     }
     //! Returns a negative duration_type
     duration_type get_neg_offset(const date_type& d) const
@@ -101,26 +152,38 @@ namespace date_time {
           origDayOfMonth_ = -1; //force the value to the end of month
         }
       }
-      typedef date_time::wrapping_int2<short,1,12> wrap_int2;
-      typedef typename wrap_int2::int_type int_type;
-      wrap_int2 wi(ymd.month);
-      //calc the year wrap around, add() returns 0 or 1 if wrapped
-      int_type year = static_cast<int_type>(wi.subtract(f_));
-      year = static_cast<int_type>(year + ymd.year); //calculate resulting year
+      month_wrapping_int wi(ymd.month);
+      //calc the year wrap around, subtract() returns the number of wraps
+      year_common_type year_offset = wi.subtract(static_cast< year_common_type >(f_));
+      year_common_type year = year_offset + ymd.year; //calculate resulting year
+      // We have to mimic the similar checks in constrained_value here because
+      // the year value may exceed the range of year_rep_type and get truncated
+      // when passed to the year_type constructor. By performing the checks on the full-sized
+      // integers here we avoid integer overflow.
+      if (BOOST_UNLIKELY(year + 1 < static_cast< year_common_type >((year_value_policy::min)() + 1))) {
+        year_value_policy::on_error(ymd.year, static_cast< year_rep_type >(year_offset), CV::min_violation);
+        return duration_type(not_a_date_time);
+      }
+      if (BOOST_UNLIKELY(year > static_cast< year_common_type >((year_value_policy::max)()))) {
+        year_value_policy::on_error(ymd.year, static_cast< year_rep_type >(year_offset), CV::max_violation);
+        return duration_type(not_a_date_time);
+      }
+
       //find the last day for the new month
-      day_type resultingEndOfMonthDay(cal_type::end_of_month_day(year, wi.as_int()));
+      day_type resultingEndOfMonthDay(cal_type::end_of_month_day(static_cast< year_rep_type >(year), wi.as_int()));
       //original was the end of month -- force to last day of month
       if (origDayOfMonth_ == -1) {
-        return date_type(year, wi.as_int(), resultingEndOfMonthDay) - d;
+        return date_type(static_cast< year_rep_type >(year), wi.as_int(), resultingEndOfMonthDay) - d;
       }
       day_type dayOfMonth = origDayOfMonth_;
       if (dayOfMonth > resultingEndOfMonthDay) {
         dayOfMonth = resultingEndOfMonthDay;
       }
-      return date_type(year, wi.as_int(), dayOfMonth) - d;
+      return date_type(static_cast< year_rep_type >(year), wi.as_int(), dayOfMonth) - d;
     }
+
   private:
-    int f_;
+    difference_type f_;
     mutable short origDayOfMonth_;
   };
 

--- a/include/boost/date_time/constrained_value.hpp
+++ b/include/boost/date_time/constrained_value.hpp
@@ -41,7 +41,8 @@ namespace CV {
   template<class value_policies>
   class BOOST_SYMBOL_VISIBLE constrained_value {
   public:
-    typedef typename value_policies::value_type value_type;
+    typedef value_policies value_policy;
+    typedef typename value_policy::value_type value_type;
     //    typedef except_type exception_type;
     constrained_value(value_type value) : value_((min)())
     {
@@ -53,9 +54,9 @@ namespace CV {
       return *this;
     }
     //! Return the max allowed value (traits method)
-    static value_type max BOOST_PREVENT_MACRO_SUBSTITUTION () {return (value_policies::max)();}
+    static value_type max BOOST_PREVENT_MACRO_SUBSTITUTION () {return (value_policy::max)();}
     //! Return the min allowed value (traits method)
-    static value_type min BOOST_PREVENT_MACRO_SUBSTITUTION () {return (value_policies::min)();}
+    static value_type min BOOST_PREVENT_MACRO_SUBSTITUTION () {return (value_policy::min)();}
     //! Coerce into the representation type
     operator value_type() const {return value_;}
   protected:
@@ -66,11 +67,11 @@ namespace CV {
       //adding 1 below gets rid of a compiler warning which occurs when the 
       //min_value is 0 and the type is unsigned....
       if (value+1 < (min)()+1) {
-        value_policies::on_error(value_, value, min_violation);
+        value_policy::on_error(value_, value, min_violation);
         return;
       }
       if (value > (max)()) {
-        value_policies::on_error(value_, value, max_violation);
+        value_policy::on_error(value_, value, max_violation);
         return;
       }
       value_ = value;


### PR DESCRIPTION
The calculated year value can exceed both the allowed year range and the
year representation type range, which can cause integer overflows when
the resulting date is constructed. The range checks in the year
constructor don't help because the new year value can be truncated before
passing to the constructor due to implicit integer conversion.

This commit performs range checks on the full-width integers before
calling the year's constructor. This somewhat duplicates the
constrained_value logic, but it gets the job done.