### PR TITLE
Silence MSVC warnings about integer truncation

### DIFF
--- a/include/boost/date_time/adjust_functors.hpp
+++ b/include/boost/date_time/adjust_functors.hpp
@@ -73,7 +73,7 @@ namespace date_time {
       typedef date_time::wrapping_int2<short,1,12> wrap_int2;
       wrap_int2 wi(ymd.month);
       //calc the year wrap around, add() returns 0 or 1 if wrapped
-      const typename ymd_type::year_type year = static_cast<typename ymd_type::year_type>(ymd.year + wi.add(f_));
+      const typename ymd_type::year_type year(static_cast<typename ymd_type::year_type::value_type>(ymd.year + wi.add(f_)));
 //       std::cout << "trace wi: " << wi.as_int() << std::endl;
 //       std::cout << "trace year: " << year << std::endl;
       //find the last day for the new month
@@ -102,7 +102,7 @@ namespace date_time {
       typedef date_time::wrapping_int2<short,1,12> wrap_int2;
       wrap_int2 wi(ymd.month);
       //calc the year wrap around, add() returns 0 or 1 if wrapped
-      const typename ymd_type::year_type year = static_cast<typename ymd_type::year_type>(ymd.year + wi.subtract(f_));
+      const typename ymd_type::year_type year(static_cast<typename ymd_type::year_type::value_type>(ymd.year + wi.subtract(f_)));
       //find the last day for the new month
       day_type resultingEndOfMonthDay(cal_type::end_of_month_day(year, wi.as_int()));
       //original was the end of month -- force to last day of month

--- a/include/boost/date_time/gregorian/greg_day.hpp
+++ b/include/boost/date_time/gregorian/greg_day.hpp
@@ -42,9 +42,9 @@ namespace gregorian {
   */
   class BOOST_SYMBOL_VISIBLE greg_day : public greg_day_rep {
   public:
-    greg_day(unsigned short day_of_month) : greg_day_rep(day_of_month) {}
-    unsigned short as_number() const {return value_;}
-    operator unsigned short()  const {return value_;}
+    greg_day(value_type day_of_month) : greg_day_rep(day_of_month) {}
+    value_type as_number() const {return value_;}
+    operator value_type()  const {return value_;}
   private:
     
   };

--- a/include/boost/date_time/gregorian/greg_month.hpp
+++ b/include/boost/date_time/gregorian/greg_month.hpp
@@ -61,11 +61,11 @@ namespace gregorian {
     greg_month(month_enum theMonth) : 
       greg_month_rep(static_cast<greg_month_rep::value_type>(theMonth)) {}
     //! Construct from a short value
-    greg_month(unsigned short theMonth) : greg_month_rep(theMonth) {}
+    greg_month(value_type theMonth) : greg_month_rep(theMonth) {}
     //! Convert the value back to a short
-    operator unsigned short()  const {return value_;}
+    operator value_type()  const {return value_;}
     //! Returns month as number from 1 to 12
-    unsigned short as_number() const {return value_;}
+    value_type as_number() const {return value_;}
     month_enum as_enum() const {return static_cast<month_enum>(value_);}
     const char* as_short_string() const;
     const char* as_long_string()  const;

--- a/include/boost/date_time/gregorian/greg_weekday.hpp
+++ b/include/boost/date_time/gregorian/greg_weekday.hpp
@@ -41,11 +41,11 @@ namespace gregorian {
   class BOOST_DATE_TIME_DECL greg_weekday : public greg_weekday_rep {
   public:
     typedef boost::date_time::weekdays weekday_enum;
-    greg_weekday(unsigned short day_of_week_num) :
+    greg_weekday(value_type day_of_week_num) :
       greg_weekday_rep(day_of_week_num)
     {}
 
-    unsigned short as_number() const {return value_;}
+    value_type as_number() const {return value_;}
     const char* as_short_string() const;
     const char* as_long_string()  const;
 #ifndef BOOST_NO_STD_WSTRING

--- a/include/boost/date_time/gregorian/greg_year.hpp
+++ b/include/boost/date_time/gregorian/greg_year.hpp
@@ -39,8 +39,8 @@ namespace gregorian {
   */
   class BOOST_SYMBOL_VISIBLE greg_year : public greg_year_rep {
   public:
-    greg_year(unsigned short year) : greg_year_rep(year) {}
-    operator unsigned short()  const {return value_;}
+    greg_year(value_type year) : greg_year_rep(year) {}
+    operator value_type()  const {return value_;}
   };
 
 


### PR DESCRIPTION
Also for day/month/year types use the value_type typedef to accept and return numeric values of the date component.