### PR TITLE
trac-13194: fix time input facet processing for %e

### DIFF
--- a/include/boost/date_time/time_facet.hpp
+++ b/include/boost/date_time/time_facet.hpp
@@ -1088,9 +1088,12 @@ namespace date_time {
                     break;
                   }
                 case 'd':
+                case 'e':
                   {
                     try {
-                      t_day = this->m_parser.parse_day_of_month(sitr, stream_end);
+                      t_day = (*itr == 'd') ?
+                          this->m_parser.parse_day_of_month(sitr, stream_end) :
+                          this->m_parser.parse_var_day_of_month(sitr, stream_end);
                     }
                     catch(std::out_of_range&) { // base class for exception bad_day_of_month
                       match_results mr;

--- a/test/posix_time/testtime_input_facet.cpp
+++ b/test/posix_time/testtime_input_facet.cpp
@@ -43,7 +43,7 @@ bool failure_test(temporal_type component,
 
 // for tests that are expected to fail quietly
 template<class temporal_type>
-bool failure_test(temporal_type component,
+bool failure_test(temporal_type& component,
                   const std::string& input,
                   boost::posix_time::time_input_facet* facet)
 {
@@ -411,8 +411,17 @@ do_all_tests()
     boost::date_time::date_generator_parser<date, char> dgp; // default constructor
     time_input_facet tif("%Y-%m-%d %H:%M:%s", fdp, svp, pp, dgp);
   }
-#endif // USE_DATE_TIME_PRE_1_33_FACET_IO
 
+  // trac 13194 (https://svn.boost.org/trac10/ticket/13194)
+  {
+      const std::string value = "December 07:27:10.435945 5 2017";
+      boost::posix_time::time_input_facet* facet = new boost::posix_time::time_input_facet("%B %H:%M:%s %e %Y");
+      boost::posix_time::ptime pt;
+      check("trac 13194 %e on \"5\" failbit set", !failure_test(pt, value, facet)); // proves failbit was not set
+      check_equal("trac 13194 %e on \" 5\" valid value", "2017-12-05T07:27:10.435945000", to_iso_extended_string(pt));
+  }
+
+#endif // USE_DATE_TIME_PRE_1_33_FACET_IO
 }
 
 

--- a/xmldoc/format_flags.xml
+++ b/xmldoc/format_flags.xml
@@ -80,7 +80,9 @@
 
           <row>
             <entry valign="top" morerows="1"><screen>%d</screen></entry>
-            <entry>Day of the month as decimal 01 to 31</entry>
+            <entry>
+              Day of the month as decimal 01 to 31.  When used to parse input, the leading zero is optional.
+            </entry>
           </row>
           <row>
             <entry><screen></screen></entry>
@@ -96,7 +98,10 @@
 
           <row>
             <entry valign="top" morerows="1"><screen>%e #</screen></entry>
-            <entry>Like %d, the day of the month as a decimal number, but a leading zero is replaced by a space</entry>
+            <entry>
+              Like %d, the day of the month as a decimal number, but a leading zero is replaced by a space.
+              When used to parse input, the leading space is optional.
+            </entry>
           </row>
           <row>
             <entry><screen></screen></entry>


### PR DESCRIPTION
Patch comes from the posted patch in the Boost Trac issue:
https://svn.boost.org/trac10/ticket/13194