### PR TITLE
trac-12910: allow %j without a year specifier - uses epoch year

### DIFF
--- a/include/boost/date_time/time_facet.hpp
+++ b/include/boost/date_time/time_facet.hpp
@@ -1230,7 +1230,7 @@ namespace date_time {
 
         date_type d(not_a_date_time);
         if (day_of_year > 0) {
-          d = date_type(static_cast<unsigned short>(t_year-1),12,31) + date_duration_type(day_of_year);
+          d = date_type(static_cast<unsigned short>(t_year),1,1) + date_duration_type(day_of_year-1);
         }
         else {
           d = date_type(t_year, t_month, t_day);

--- a/test/posix_time/testtime_input_facet.cpp
+++ b/test/posix_time/testtime_input_facet.cpp
@@ -421,6 +421,15 @@ do_all_tests()
       check_equal("trac 13194 %e on \" 5\" valid value", "2017-12-05T07:27:10.435945000", to_iso_extended_string(pt));
   }
 
+  // trac 12910
+  {
+      const std::string value = "263-08:09:10";
+      boost::posix_time::time_input_facet* facet = new boost::posix_time::time_input_facet("%j-%H:%M:%S");
+      boost::posix_time::ptime pt;
+      check("trac 12910 %j without %Y no failbit", !failure_test(pt, value, facet)); // proves failbit was not set
+      check_equal("trac 12910 %j without %Y value", "1400-09-20T08:09:10", to_iso_extended_string(pt));
+  }
+
 #endif // USE_DATE_TIME_PRE_1_33_FACET_IO
 }
 


### PR DESCRIPTION
https://svn.boost.org/trac10/ticket/12910