### PR TITLE
trac-12363: fix const correctness issue in operator implementations

### DIFF
--- a/include/boost/date_time/int_adapter.hpp
+++ b/include/boost/date_time/int_adapter.hpp
@@ -136,9 +136,7 @@ public:
   }
   bool operator==(const int& rhs) const
   {
-    // quiets compiler warnings
-    bool is_signed = std::numeric_limits<int_type>::is_signed;
-    if(!is_signed)
+    if(!std::numeric_limits<int_type>::is_signed)
     {
       if(is_neg_inf(value_) && rhs == 0)
       {
@@ -153,9 +151,7 @@ public:
   }
   bool operator!=(const int& rhs) const
   {
-    // quiets compiler warnings
-    bool is_signed = std::numeric_limits<int_type>::is_signed;
-    if(!is_signed)
+    if(!std::numeric_limits<int_type>::is_signed)
     {
       if(is_neg_inf(value_) && rhs == 0)
       {
@@ -171,8 +167,7 @@ public:
   bool operator<(const int& rhs) const
   {
     // quiets compiler warnings
-    bool is_signed = std::numeric_limits<int_type>::is_signed;
-    if(!is_signed)
+    if(!std::numeric_limits<int_type>::is_signed)
     {
       if(is_neg_inf(value_) && rhs == 0)
       {


### PR DESCRIPTION
Now I'm fixing bugs I reported, yay!

The code I fixed up is over 14 years old.  The comments are probably for msvc-6.0 or something.