### PR TITLE
trac-11168: special_values handling in time duration helpers

### DIFF
--- a/include/boost/date_time/posix_time/posix_time_duration.hpp
+++ b/include/boost/date_time/posix_time/posix_time_duration.hpp
@@ -9,42 +9,54 @@
  * $Date$
  */
 
+#include <boost/core/enable_if.hpp>
 #include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/posix_time/posix_time_config.hpp>
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/type_traits/is_integral.hpp>
 
 namespace boost {
 namespace posix_time {
 
   //! Allows expression of durations as an hour count
+  //! The argument must be an integral type
   /*! \ingroup time_basics
    */
   class BOOST_SYMBOL_VISIBLE hours : public time_duration
   {
   public:
-    explicit hours(long h) :
-      time_duration(static_cast<hour_type>(h),0,0)
+      template <typename T>
+      explicit hours(T const& h,
+          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+      time_duration(numeric_cast<hour_type>(h), 0, 0)
     {}
   };
 
   //! Allows expression of durations as a minute count
+  //! The argument must be an integral type
   /*! \ingroup time_basics
    */
   class BOOST_SYMBOL_VISIBLE minutes : public time_duration
   {
   public:
-    explicit minutes(long m) :
-      time_duration(0,static_cast<min_type>(m),0)
+      template <typename T>
+      explicit minutes(T const& m,
+          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+      time_duration(0, numeric_cast<min_type>(m),0)
     {}
   };
 
   //! Allows expression of durations as a seconds count
+  //! The argument must be an integral type
   /*! \ingroup time_basics
    */
   class BOOST_SYMBOL_VISIBLE seconds : public time_duration
   {
   public:
-    explicit seconds(long s) :
-      time_duration(0,0,static_cast<sec_type>(s))
+      template <typename T>
+      explicit seconds(T const& s,
+          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+      time_duration(0,0, numeric_cast<sec_type>(s))
     {}
   };
 
@@ -70,11 +82,7 @@ namespace posix_time {
   typedef date_time::subsecond_duration<time_duration,1000000000> nanosec;
   typedef date_time::subsecond_duration<time_duration,1000000000> nanoseconds;
 
-
 #endif
-
-
-
 
 } }//namespace posix_time
 

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -9,12 +9,14 @@
  * $Date$
  */
 
+#include <boost/core/enable_if.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/special_defs.hpp>
+#include <boost/date_time/time_defs.hpp>
 #include <boost/operators.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/date_time/time_defs.hpp>
-#include <boost/date_time/special_defs.hpp>
-#include <boost/date_time/compiler_config.hpp>
+#include <boost/type_traits/is_integral.hpp>
 
 namespace boost {
 namespace date_time {
@@ -262,7 +264,7 @@ namespace date_time {
 
   //! Template for instantiating derived adjusting durations
   /* These templates are designed to work with multiples of
-   * 10 for frac_of_second and resoultion adjustment
+   * 10 for frac_of_second and resolution adjustment
    */
   template<class base_duration, boost::int64_t frac_of_second>
   class BOOST_SYMBOL_VISIBLE subsecond_duration : public base_duration
@@ -278,13 +280,14 @@ namespace date_time {
     BOOST_STATIC_CONSTANT(boost::int64_t, adjustment_ratio = (traits_type::ticks_per_second >= frac_of_second ? traits_type::ticks_per_second / frac_of_second : frac_of_second / traits_type::ticks_per_second));
 
   public:
-    explicit subsecond_duration(boost::int64_t ss) :
+    // The argument (ss) must be an integral type
+    template <typename T>
+    explicit subsecond_duration(T const& ss,
+                                typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
       base_duration(impl_type(traits_type::ticks_per_second >= frac_of_second ? ss * adjustment_ratio : ss / adjustment_ratio))
     {
     }
   };
-
-
 
 } } //namespace date_time
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,4 +1,4 @@
-
+import testing ;
 
 local DATE_TIME_DYNAMIC_PROPERTIES = <define>BOOST_ALL_DYN_LINK <runtime-link>shared <define>BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG <define>BOOST_ALL_NO_LIB ;
 local DATE_TIME_PROPERTIES = <define>BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG <define>BOOST_DATE_TIME_STATIC_LINK
@@ -74,6 +74,10 @@ test-suite date_time_gregorian_dll
    [ run posix_time/testduration.cpp
      ../build//boost_date_time/<link>static
     : : :  $(DATE_TIME_PROPERTIES) ]
+   [ compile-fail posix_time/compile_fail/hours_special_value.cpp ]
+   [ compile-fail posix_time/compile_fail/minutes_special_value.cpp ]
+   [ compile-fail posix_time/compile_fail/seconds_special_value.cpp ]
+   [ compile-fail posix_time/compile_fail/millisec_special_value.cpp ]
    [ run posix_time/testiterator.cpp
      ../build//boost_date_time/<link>static
     : : :  $(DATE_TIME_PROPERTIES) ]

--- a/test/posix_time/compile_fail/hours_special_value.cpp
+++ b/test/posix_time/compile_fail/hours_special_value.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2017 James E. King III
+// Use, modification and distribution is subject to the
+// Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "boost/date_time/posix_time/posix_time_duration.hpp"
+#include "boost/date_time/special_defs.hpp"
+
+int main()
+{
+    using boost::date_time::pos_infin;
+    using boost::posix_time::hours;
+    using boost::posix_time::time_duration;
+    time_duration dur1 = hours(static_cast<boost::int64_t>(pos_infin));  // compiles: it's an integral
+    time_duration dur2 = hours(pos_infin);                               // won't compile: not an integral
+    return 1;                                                            // return an error if we actually run for some reason
+}

--- a/test/posix_time/compile_fail/millisec_special_value.cpp
+++ b/test/posix_time/compile_fail/millisec_special_value.cpp
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2017 James E. King III
+// Use, modification and distribution is subject to the
+// Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "boost/date_time/posix_time/posix_time_duration.hpp"
+#include "boost/date_time/special_defs.hpp"
+
+int main()
+{
+    using boost::date_time::pos_infin;
+    using boost::posix_time::millisec;
+    millisec ms(static_cast<boost::int64_t>(pos_infin));   // compiles: it's a number
+    millisec nc(pos_infin);                                // won't compile: not an integral
+    return 1;                                              // return an error if we actually run for some reason
+}

--- a/test/posix_time/compile_fail/minutes_special_value.cpp
+++ b/test/posix_time/compile_fail/minutes_special_value.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2017 James E. King III
+// Use, modification and distribution is subject to the
+// Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "boost/date_time/posix_time/posix_time_duration.hpp"
+#include "boost/date_time/special_defs.hpp"
+
+int main()
+{
+    using boost::date_time::pos_infin;
+    using boost::posix_time::minutes;
+    using boost::posix_time::time_duration;
+    time_duration dur1 = minutes(static_cast<boost::int64_t>(pos_infin));  // compiles: it's an integral
+    time_duration dur2 = minutes(pos_infin);                               // won't compile: not an integral
+    return 1;                                                              // return an error if we actually run for some reason
+}

--- a/test/posix_time/compile_fail/seconds_special_value.cpp
+++ b/test/posix_time/compile_fail/seconds_special_value.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2017 James E. King III
+// Use, modification and distribution is subject to the
+// Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "boost/date_time/posix_time/posix_time_duration.hpp"
+#include "boost/date_time/special_defs.hpp"
+
+int main()
+{
+    using boost::date_time::pos_infin;
+    using boost::posix_time::seconds;
+    using boost::posix_time::time_duration;
+    time_duration dur1 = seconds(static_cast<boost::int64_t>(pos_infin));  // compiles: it's an integral
+    time_duration dur2 = seconds(pos_infin);                               // won't compile: not an integral
+    return 1;                                                              // return an error if we actually run for some reason
+}


### PR DESCRIPTION
https://svn.boost.org/trac10/ticket/11168

Ensure special values are not automatically translated to integral types in the hours, minutes, seconds, and fractional seconds time duration helpers.   For example:

```
// pos_infin is an enum which converts to long automagically
time_duration dur = seconds(pox_infin);
assert(dur.total_seconds() == 2);
```

Obviously the special_values should not be used in this way, but the compiler wasn't failing it.
This approach as suggested in trac-11168 is to use SFINAE to fix that.  I was able to do hours(), minutes(), seconds(), and fractional seconds helpers.  If you try to use a special_values value:

```
clang-linux.compile.c++.without-pth ../../../bin.v2/libs/date_time/test/minutes_special_value.test/clang-gnu-linux-5.0.0/debug/cxxstd-17-iso/threadapi-pthread/minutes_special_value.o
posix_time/compile_fail/minutes_special_value.cpp:17:26: error: no matching conversion for functional-style cast from 'boost::date_time::special_values' to 'boost::posix_time::minutes'
    time_duration dur2 = minutes(pos_infin);                               // won't compile: not an integral
                         ^~~~~~~~~~~~~~~~~
../../../boost/date_time/posix_time/posix_time_duration.hpp:39:30: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'boost::date_time::special_values' to 'const boost::posix_time::minutes' for 1st argument
  class BOOST_SYMBOL_VISIBLE minutes : public time_duration
                             ^
../../../boost/date_time/posix_time/posix_time_duration.hpp:39:30: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'boost::date_time::special_values' to 'boost::posix_time::minutes' for 1st argument
../../../boost/date_time/posix_time/posix_time_duration.hpp:44:37: note: candidate template ignored: disabled by 'enable_if' [with T = boost::date_time::special_values]
          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
                                    ^
1 error generated.
(failed-as-expected) ../../../bin.v2/libs/date_time/test/minutes_special_value.test/clang-gnu-linux-5.0.0/debug/cxxstd-17-iso/threadapi-pthread/minutes_special_value.o
```

Note this PR does not tackle time_duration itself, which can still be confused by:

```
time_duration dur(0, 0, pos_infin, 0); 
assert(dur.total_seconds() == 2);
```

It wasn't trivial to fix this, however this is an improvement, so I think it stands on its own, assuming folks are okay with it.