### PR TITLE
issue-56: fix 32/64 bit test issue with previous fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/test/time_duration_serialization.v0
-/test/time_duration_serialization.v1
-/test/test_facet_file.out
+**/time_duration_serialization.*
+**/test_facet_file.out

--- a/test/posix_time/testtime_serialize_versioning.cpp
+++ b/test/posix_time/testtime_serialize_versioning.cpp
@@ -15,42 +15,50 @@
 using namespace boost;
 using namespace posix_time;
 
-void check_filesize(const char* filename, std::ifstream::pos_type expectedSize)
+void check_filesize(const std::string& filename, std::ifstream::pos_type expectedSize)
 {
-    std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
+    std::ifstream in(filename.c_str(), std::ifstream::ate | std::ifstream::binary);
     check_equal("check file size is " + boost::lexical_cast<std::string>(expectedSize), in.tellg(), expectedSize);
 }
 
+std::string get_fname(int version)
+{
+    return "time_duration_serialization." +
+        std::string((sizeof(size_t) == 4) ? "x32" : "x64") +
+        ".v" + boost::lexical_cast<std::string>(version);
+}
+
 int main() {
-    const char *fname = "time_duration_serialization.v0";
     time_duration td(12, 13, 52, 123456);
 
 #if BOOST_DATE_TIME_POSIX_TIME_DURATION_VERSION == 0
-    std::ofstream ofs(fname, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
+    std::ofstream ofs(get_fname(0).c_str(), std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
     boost::archive::binary_oarchive oa(ofs);
     oa << td;
     ofs.close();
 
 #if defined(_MSC_VER)
-    check_filesize(fname, 62);
+    check_filesize(get_fname(0), 58 + sizeof(size_t));
 #endif
-#else
-    std::ifstream ifs(fname, std::ios_base::binary | std::ios_base::in);
+
+#else // BOOST_DATE_TIME_POSIX_TIME_DURATION_VERSION > 0
+    std::ifstream ifs(get_fname(0).c_str(), std::ios_base::binary | std::ios_base::in);
     boost::archive::binary_iarchive ia(ifs);
     time_duration tmp;
     ia >> tmp;
     ifs.close();
     check_equal("read older version structure ok", td, tmp);
 
-    std::ofstream ofs("time_duration_serialization.v1", std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
+    std::ofstream ofs(get_fname(1).c_str(), std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
     boost::archive::binary_oarchive oa(ofs);
     oa << td;
     ofs.close();
 
 #if defined(_MSC_VER)
-    check_filesize("time_duration_serialization.v1", 74);
+    check_filesize(get_fname(1), 70 + sizeof(size_t));
 #endif
-#endif
+
+#endif // BOOST_DATE_TIME_POSIX_TIME_DURATION_VERSION
 
     return printTestStats();
 }


### PR DESCRIPTION
The test was not accounting for binary size differences in the 32/64 bit outputs.

Caused by:

https://github.com/boostorg/date_time/pull/58
  