### PR TITLE
trac-13159, trac-12630: fix maximum year to 9999

### DIFF
--- a/include/boost/date_time/gregorian/greg_year.hpp
+++ b/include/boost/date_time/gregorian/greg_year.hpp
@@ -21,19 +21,19 @@ namespace gregorian {
   struct BOOST_SYMBOL_VISIBLE bad_year : public std::out_of_range
   {
     bad_year() : 
-      std::out_of_range(std::string("Year is out of valid range: 1400..10000")) 
+      std::out_of_range(std::string("Year is out of valid range: 1400..9999")) 
     {}
   };
   //! Policy class that declares error handling gregorian year type
-  typedef CV::simple_exception_policy<unsigned short, 1400, 10000, bad_year> greg_year_policies;
+  typedef CV::simple_exception_policy<unsigned short, 1400, 9999, bad_year> greg_year_policies;
 
   //! Generated representation for gregorian year
   typedef CV::constrained_value<greg_year_policies> greg_year_rep;
 
-  //! Represent a year (range 1400 - 10000) 
+  //! Represent a year (range 1400 - 9999) 
   /*! This small class allows for simple conversion an integer value into
       a year for the gregorian calendar.  This currently only allows a
-      range of 1400 to 10000.  Both ends of the range are a bit arbitrary
+      range of 1400 to 9999.  Both ends of the range are a bit arbitrary
       at the moment, but they are the limits of current testing of the 
       library.  As such they may be increased in the future.
   */

--- a/test/gregorian/testdate.cpp
+++ b/test/gregorian/testdate.cpp
@@ -5,10 +5,23 @@
  * Author: Jeff Garland, Bart Garst
  */
 
-#include <iostream>
 #include <boost/cstdint.hpp>
 #include "boost/date_time/gregorian/gregorian.hpp"
 #include "../testfrmwk.hpp"
+#include <iostream>
+#include <sstream>
+
+void test_yearlimit(int yr, bool allowed)
+{
+    std::stringstream sdesc;
+    sdesc << "should" << (allowed ? "" : " not") << " be able to make a date in year " << yr;
+
+    try {
+        boost::gregorian::date chkyr(yr, 1, 1);
+        check(sdesc.str(), allowed);
+    }
+    catch (std::out_of_range&) { check(sdesc.str(), !allowed); }
+}
 
 int
 main()
@@ -292,7 +305,15 @@ main()
     check("Caught un-expected exception (special_value to_tm)", false);
   }
 
-  return printTestStats();
+  // trac-13159
+  test_yearlimit(    0, false);
+  test_yearlimit( 1399, false);
+  test_yearlimit( 1400,  true);
+  test_yearlimit( 1401,  true);
+  test_yearlimit( 9999,  true);
+  test_yearlimit(10000, false);
+  test_yearlimit(10001, false);
 
+  return printTestStats();
 }
 

--- a/test/gregorian/testgreg_durations.cpp
+++ b/test/gregorian/testgreg_durations.cpp
@@ -158,17 +158,17 @@ int main(){
 
     try {
       date d1(1400, 6, 1);
-      const date d2 = d1 + years(8600);
-      check("date + many years != overflow", d2 == date(10000, 6, 1));
+      const date d2 = d1 + years(8599);
+      check("date + many years != overflow", d2 == date(9999, 6, 1));
     }
     catch (...) {
       check("date + many years != overflow", false);
     }
 
     try {
-      date d1(10000, 6, 1);
-      const date d2 = d1 - years(8600);
-      check("date - many years != overflow", d2 == date(1400, 6, 1));
+      date d1(9999, 1, 1);
+      const date d2 = d1 - years(8599);
+      check("date - many years != overflow", d2 == date(1400, 1, 1));
     }
     catch (...) {
       check("date - many years != overflow", false);

--- a/test/gregorian/testgreg_year.cpp
+++ b/test/gregorian/testgreg_year.cpp
@@ -8,41 +8,38 @@
 #include "boost/date_time/gregorian/greg_year.hpp"
 #include "../testfrmwk.hpp"
 #include <iostream>
+#include <sstream>
 
+void test_yearlimit(int yr, bool allowed)
+{
+    std::stringstream sdesc;
+    sdesc << "should" << (allowed ? "" : " not") << " be able to make a year " << yr;
+
+    try {
+        boost::gregorian::greg_year chkyr(yr);
+        check(sdesc.str(), allowed);
+        if (allowed) {
+            check_equal("year operator ==", chkyr, yr);
+        }
+    }
+    catch (std::out_of_range&) { check(sdesc.str(), !allowed); }
+}
 
 int
 main() 
 {
+  // trac-13159 better limit testing
+  test_yearlimit(    0, false);
+  test_yearlimit( 1399, false);
+  test_yearlimit( 1400,  true);
+  test_yearlimit( 1401,  true);
+  test_yearlimit( 9999,  true);
+  test_yearlimit(10000, false);
+  test_yearlimit(10001, false);
 
-  using namespace boost::gregorian;
-  greg_year d1(1400);
-  check("Basic of min", d1 == 1400);
-  greg_year d2(10000);
-  check("Basic test of max", d2 == 10000);
-  try {
-    greg_year bad(0);
-    check("Bad year creation", false); //oh oh, fail
-    //unreachable
-    std::cout << "Shouldn't reach here: " << bad << std::endl;
-  }
-  catch(std::exception &) {
-    check("Bad year creation", true); //good
-    
-  }
-  try {
-    greg_year bad(10001);
-    check("Bad year creation2", false); //oh oh, fail
-    //unreachable
-    std::cout << "Shouldn't reach here: " << bad << std::endl;
-  }
-  catch(std::exception&) {
-    check("Bad year creation2", true); //good
-    
-  }
-  check("traits min year", (greg_year::min)() ==  1400);
-  check("traits max year", (greg_year::max)() == 10000);
+  check("traits min year", (boost::gregorian::greg_year::min)() == 1400);
+  check("traits max year", (boost::gregorian::greg_year::max)() == 9999);
 
-  printTestStats();
-  return 0;
+  return printTestStats();
 }
 


### PR DESCRIPTION
#### Background ####
https://svn.boost.org/trac10/ticket/13159
https://svn.boost.org/trac10/ticket/12630

#### Notes ####
The documentation already specifies that the maximum year is 9999 so there are no documentation changes.  This pull request fixes the code to match the documentation.

Why it allowed 10000 is beyond me, but it didn't make much sense.  10001 was not allowed for example.  Given year handling is all documented as "YYYY" there's no reason to allow 10000 to slip through.  It simply looks like there was a poor decision made in this area that this pull request corrects.