### PR TITLE
Silence MSVC warnings about conditional expression being constant.

### DIFF
--- a/include/boost/date_time/int_adapter.hpp
+++ b/include/boost/date_time/int_adapter.hpp
@@ -18,6 +18,12 @@
 #  include <ostream>
 #endif
 
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+// conditional expression is constant
+#pragma warning(disable: 4127)
+#endif
+
 namespace boost {
 namespace date_time {
 
@@ -483,6 +489,8 @@ private:
 
 } } //namespace date_time
 
-
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
 
 #endif


### PR DESCRIPTION
The warning is emitted whereever `std::numeric_limits<>::is_signed` is used in a conditional statement.