### PR TITLE
Fix MSVC Y2K38 bug in from_time_t

### DIFF
--- a/include/boost/date_time/posix_time/conversion.hpp
+++ b/include/boost/date_time/posix_time/conversion.hpp
@@ -26,7 +26,7 @@ namespace posix_time {
   inline
   ptime from_time_t(std::time_t t)
   {
-    return ptime(gregorian::date(1970,1,1)) + seconds(static_cast<long>(t));
+    return ptime(gregorian::date(1970,1,1)) + seconds(t);
   }
 
   //! Function that converts a ptime into a time_t

--- a/test/posix_time/testtime.cpp
+++ b/test/posix_time/testtime.cpp
@@ -306,6 +306,18 @@ main()
         t18 == ptime(date(2032,2,15), time_duration(18,47,14)));
   check("time_t conversion from 1960483634", to_time_t(t18) == tt3);
 
+#if !defined(BOOST_NO_INT64_T)
+  // 64-bit time_t test (if running with a 64-bit time_t)
+  if (sizeof(std::time_t) >= 8)
+  {
+    std::time_t tt4(INT64_C(11864480887)); 
+    t18 = from_time_t(tt4); //2345-12-21 09:08:07
+    check("time_t conversion of 11864480887", 
+          t18 == ptime(date(2345,12,21), time_duration(9,8,7)));
+    check("time_t conversion from 11864480887", to_time_t(t18) == tt4);
+  }
+#endif
+  
   special_values_tests();
 
   //min and max constructors


### PR DESCRIPTION
from_time_t was altered recently to cast the incoming value to a long. On LLP64 platforms, such as Windows, this truncates the value to 32-bit. My proposed patch casts to int64_t.

I've also added a unit test involving a 64-bit time_t conversion.

This fixes #87 