### PR TITLE
Use nullptr instead of 0 if possible

### DIFF
--- a/include/boost/date_time/compiler_config.hpp
+++ b/include/boost/date_time/compiler_config.hpp
@@ -165,5 +165,10 @@ namespace std {
 #  endif
 #endif
 
+#if defined(BOOST_NO_CXX11_NULLPTR)
+#  define BOOST_DATE_TIME_NULLPTR 0
+#else
+#  define BOOST_DATE_TIME_NULLPTR nullptr
+#endif
 
 #endif

--- a/include/boost/date_time/posix_time/posix_time_duration.hpp
+++ b/include/boost/date_time/posix_time/posix_time_duration.hpp
@@ -27,7 +27,7 @@ namespace posix_time {
   public:
       template <typename T>
       explicit hours(T const& h,
-          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+          typename boost::enable_if<boost::is_integral<T>, void>::type* = BOOST_DATE_TIME_NULLPTR) :
       time_duration(numeric_cast<hour_type>(h), 0, 0)
     {}
   };
@@ -41,7 +41,7 @@ namespace posix_time {
   public:
       template <typename T>
       explicit minutes(T const& m,
-          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+          typename boost::enable_if<boost::is_integral<T>, void>::type* = BOOST_DATE_TIME_NULLPTR) :
       time_duration(0, numeric_cast<min_type>(m),0)
     {}
   };
@@ -55,7 +55,7 @@ namespace posix_time {
   public:
       template <typename T>
       explicit seconds(T const& s,
-          typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+          typename boost::enable_if<boost::is_integral<T>, void>::type* = BOOST_DATE_TIME_NULLPTR) :
       time_duration(0,0, numeric_cast<sec_type>(s))
     {}
   };

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -283,7 +283,7 @@ namespace date_time {
     // The argument (ss) must be an integral type
     template <typename T>
     explicit subsecond_duration(T const& ss,
-                                typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
+                                typename boost::enable_if<boost::is_integral<T>, void>::type* = BOOST_DATE_TIME_NULLPTR) :
       base_duration(impl_type(traits_type::ticks_per_second >= frac_of_second ? ss * adjustment_ratio : ss / adjustment_ratio))
     {
     }


### PR DESCRIPTION
This is to prevent gcc's -Wzero-as-nullptr-constant warnings