### PR TITLE
Renamed parameter dst_length_minutes to dst_length.

### DIFF
--- a/include/boost/date_time/dst_rules.hpp
+++ b/include/boost/date_time/dst_rules.hpp
@@ -104,14 +104,14 @@ namespace boost {
                    const time_duration_type& dst_start_offset,
                    const date_type& dst_end_day,
                    const time_duration_type& dst_end_offset,
-                   const time_duration_type& dst_length_minutes)
+                   const time_duration_type& dst_length)
       {
         unsigned int start_minutes = static_cast<unsigned>(
           dst_start_offset.hours() * 60 + dst_start_offset.minutes());
         unsigned int end_minutes = static_cast<unsigned>(
           dst_end_offset.hours() * 60 + dst_end_offset.minutes());
         long length_minutes = static_cast<long>(
-          dst_length_minutes.hours() * 60 + dst_length_minutes.minutes());
+          dst_length.hours() * 60 + dst_length.minutes());
 
         return local_is_dst(current_day, time_of_day,
                             dst_start_day, start_minutes,


### PR DESCRIPTION
Use the more general name on a time duration type.