### PR TITLE
Fix doxygen clang warnings

### DIFF
--- a/include/boost/date_time/date_generators.hpp
+++ b/include/boost/date_time/date_generators.hpp
@@ -25,7 +25,7 @@ namespace date_time {
   //! Base class for all generators that take a year and produce a date.
   /*! This class is a base class for polymorphic function objects that take
     a year and produce a concrete date.
-    @param date_type The type representing a date.  This type must
+    @tparam date_type The type representing a date.  This type must
     export a calender_type which defines a year_type.
   */
   template<class date_type>
@@ -307,7 +307,7 @@ namespace date_time {
   /*! Useful generator functor for finding holidays and daylight savings
    *  Get the last day of the month and then calculate the difference
    *  to the last previous day.
-   *  @param date_type A date class that exports day_of_week, month_type, etc.
+   *  @tparam date_type A date class that exports day_of_week, month_type, etc.
    *  \ingroup date_alg
    */
   template<class date_type>

--- a/include/boost/date_time/dst_rules.hpp
+++ b/include/boost/date_time/dst_rules.hpp
@@ -94,7 +94,7 @@ namespace boost {
        *  @param dst_start_offset Time offset within day for dst boundary
        *  @param dst_end_day    Ending day of dst for the given locality
        *  @param dst_end_offset Time offset within day given in dst for dst boundary
-       *  @param dst_length lenght of dst adjusment
+       *  @param dst_length_minutes length of dst adjusment
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
       static time_is_dst_result 

--- a/include/boost/date_time/dst_transition_generators.hpp
+++ b/include/boost/date_time/dst_transition_generators.hpp
@@ -29,7 +29,7 @@ namespace date_time {
     //! Canonical form for a class that provides day rule calculation
     /*! This class is used to generate specific sets of dst rules
      *  
-     *@param spec Provides a specifiction of the function object types used
+     *@tparam spec Provides a specifiction of the function object types used
      *            to generate start and end days of daylight savings as well
      *            as the date type.
      */

--- a/include/boost/date_time/gregorian_calendar.hpp
+++ b/include/boost/date_time/gregorian_calendar.hpp
@@ -20,10 +20,10 @@ namespace date_time {
       can be used in the creation of date systems or just to perform calculations.
       All the methods of this class are static functions, so the intent is to
       never create instances of this class.
-    @param ymd_type_ Struct type representing the year, month, day.  The ymd_type must
+    @tparam ymd_type_ Struct type representing the year, month, day.  The ymd_type must
            define a of types for the year, month, and day.  These types need to be
            arithmetic types.
-    @param date_int_type_ Underlying type for the date count.  Must be an arithmetic type.
+    @tparam date_int_type_ Underlying type for the date count.  Must be an arithmetic type.
   */
   template<typename ymd_type_, typename date_int_type_>
   class BOOST_SYMBOL_VISIBLE gregorian_calendar_base {

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -29,8 +29,8 @@ namespace date_time {
       This design allows the subclass duration types to provide custom
       construction policies or other custom features not provided here.
 
-      @param T The subclass type
-      @param rep_type The time resolution traits for this duration type.
+      @tparam T The subclass type
+      @tparam rep_type The time resolution traits for this duration type.
   */
   template<class T, typename rep_type>
   class BOOST_SYMBOL_VISIBLE time_duration : private

--- a/include/boost/date_time/time_zone_base.hpp
+++ b/include/boost/date_time/time_zone_base.hpp
@@ -70,7 +70,7 @@ namespace date_time {
 
   //! Structure which holds the time offsets associated with daylight savings time
   /*!
-   *@param time_duration_type A type used to represent the offset
+   *@tparam time_duration_type A type used to represent the offset
    */
   template<class time_duration_type>
   class dst_adjustment_offsets

--- a/include/boost/date_time/time_zone_names.hpp
+++ b/include/boost/date_time/time_zone_names.hpp
@@ -43,7 +43,7 @@ namespace date_time {
    *  name: Pacific Standard Time and the abbreviated name: PST.
    *  During daylight savings there are additional names:
    *  Pacific Daylight Time and PDT. 
-   *@parm CharT Allows class to support different character types
+   *@tparam CharT Allows class to support different character types
    */
   template<class CharT>
   class time_zone_names_base


### PR DESCRIPTION
- fix a parameter name and a typo
- use `@tparam` instead of `@param` for template parameters