### PR TITLE
Improve performance of adding and subtracting time durations from ptime

### DIFF
--- a/include/boost/date_time/time.hpp
+++ b/include/boost/date_time/time.hpp
@@ -164,7 +164,7 @@ namespace date_time {
     }
     time_type operator+=(const time_duration_type& td)
     {
-      time_ = (time_system::get_time_rep(date(), time_of_day() + td));
+      time_ = time_system::add_time_duration(time_,td);
       return time_type(time_);
     }
     //! subtract time durations
@@ -174,7 +174,7 @@ namespace date_time {
     }
     time_type operator-=(const time_duration_type& td) 
     {
-      time_ = (time_system::get_time_rep(date(), time_of_day() - td));
+      time_ = time_system::subtract_time_duration(time_, td);
       return time_type(time_);
     }
     


### PR DESCRIPTION
Modifying ptime objects by adding and subtracting time durations was
inefficient because it extracted the date and time of day and then
re-constructed a ptime using the date and modified time of day.

This can be avoided by using the existing time_system utilities which
perform the operation by adjusting the number of ticks.

Performance is improved by a factor of 48 on my system.