### PR TITLE
Fix unsigned / signed conversion

### DIFF
--- a/include/boost/date_time/gregorian/greg_date.hpp
+++ b/include/boost/date_time/gregorian/greg_date.hpp
@@ -120,7 +120,7 @@ namespace gregorian {
     date end_of_month() const
     {
       ymd_type ymd = year_month_day();
-      short eom_day =  gregorian_calendar::end_of_month_day(ymd.year, ymd.month);
+      unsigned short eom_day =  gregorian_calendar::end_of_month_day(ymd.year, ymd.month);
       return date(ymd.year, ymd.month, eom_day);
     }
 


### PR DESCRIPTION
gregorian_calendar::end_of_month_day returns unsigned short and date constructor uses unsigned short.
So eom_day should be unsigned too.

Fix a Visual Studio warning.