### PR TITLE
Synchronize each miscrosec test to the next second

### DIFF
--- a/test/posix_time/testmicrosec_time_clock.cpp
+++ b/test/posix_time/testmicrosec_time_clock.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2002,2003 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
@@ -12,8 +12,34 @@
 #include <windows.h>
 #endif
 
+void
+sync_to_next_second()
+{
+  using namespace boost::posix_time;
+
+  ptime t_prev;
+  ptime t_now = second_clock::local_time();
+
+  // Wait the next seconds
+  do
+  {
+    t_prev = t_now;
+    t_now = second_clock::local_time();
+  } while (t_now.time_of_day().seconds() == t_prev.time_of_day().seconds());
+
+  // Wait 300ms in order to avoid seconds of second_clock > microsec_clock.
+  t_now = microsec_clock::local_time();
+  t_prev = t_now;
+  do
+  {
+    t_now = microsec_clock::local_time();
+  } while (t_now - t_prev < milliseconds(300));
+
+}
+
+
 int
-main() 
+main()
 {
 #ifdef BOOST_DATE_TIME_HAS_HIGH_PRECISION_CLOCK
 
@@ -26,39 +52,32 @@ main()
   int i = 0;
   for (i = 0; i<max; i++)
   {
-    for (int j=0; j<100000; j++)
-    {
-      // some systems loop too fast so "last is less" tests fail
-      // due to 'last' & 't2' being equal. These calls slow
-      // it down enough to make 'last' & 't2' different
-#if defined(BOOST_HAS_GETTIMEOFDAY)
-      timeval tv;
-      gettimeofday(&tv, 0);
-#endif
-#if defined(BOOST_HAS_FTIME)
-      SYSTEMTIME st;
-      GetSystemTime(&st);
-#endif
-    }
+    // Some systems loop too fast so "last is less" tests fail due to
+    // 'last' & 't2' being equal. These calls slow it down enough to
+    // make 'last' & 't2' different. Moreover, we must wait the next
+    // second to avoid a change in hour, minute or second field
+    // between acquisition of t1 and t2.
+    sync_to_next_second();
 
     ptime t1 = second_clock::local_time();
     std::cout << to_simple_string(t1) << std::endl;
 
     ptime t2 = microsec_clock::local_time();
     std::cout << to_simple_string(t2) << std::endl;
+
     check("hours match", t1.time_of_day().hours() == t2.time_of_day().hours());
-    check("minutes match", 
+    check("minutes match",
           t1.time_of_day().minutes() == t2.time_of_day().minutes());
-    check("seconds match", 
-          t1.time_of_day().minutes() == t2.time_of_day().minutes());
+    check("seconds match",
+          t1.time_of_day().seconds() == t2.time_of_day().seconds());
     check("hours date", t1.date() == t2.date());
     if( !check("last is less", last <= t2) ) {
-      std::cout << to_simple_string(last) << " < " 
+      std::cout << to_simple_string(last) << " < "
         << to_simple_string(t2) << std::endl;
     }
     last = t2;
 
-    
+
   }
 
 
@@ -67,40 +86,33 @@ main()
   last = microsec_clock::universal_time();
   for (i = 0; i<max; i++)
   {
-    for (int j=0; j<100000; j++)
-    {
-      // some systems loop too fast so "last is less" tests fail
-      // due to 'last' & 't2' being equal. These calls slow
-      // it down enough to make 'last' & 't2' different
-#if defined(BOOST_HAS_GETTIMEOFDAY)
-      timeval tv;
-      gettimeofday(&tv, 0);
-#endif
-#if defined(BOOST_HAS_FTIME)
-      SYSTEMTIME st;
-      GetSystemTime(&st);
-#endif
-    }
+    // Some systems loop too fast so "last is less" tests fail due to
+    // 'last' & 't2' being equal. These calls slow it down enough to
+    // make 'last' & 't2' different. Moreover, we must wait the next
+    // second to avoid a change in hour, minute or second field
+    // between acquisition of t1 and t2.
+    sync_to_next_second();
 
     ptime t1 = second_clock::universal_time();
     std::cout << to_simple_string(t1) << std::endl;
 
     ptime t2 = microsec_clock::universal_time();
     std::cout << to_simple_string(t2) << std::endl;
+
     check("hours match", t1.time_of_day().hours() == t2.time_of_day().hours());
-    check("minutes match", 
+    check("minutes match",
           t1.time_of_day().minutes() == t2.time_of_day().minutes());
-    check("seconds match", 
-          t1.time_of_day().minutes() == t2.time_of_day().minutes());
+    check("seconds match",
+          t1.time_of_day().seconds() == t2.time_of_day().seconds());
     check("hours date", t1.date() == t2.date());
     //following check might be equal on a really fast machine
     if( !check("last is less", last <= t2) ) {
-      std::cout << to_simple_string(last) << " < " 
+      std::cout << to_simple_string(last) << " < "
         << to_simple_string(t2) << std::endl;
     }
     last = t2;
 
-    
+
   }
 
 #else
@@ -109,4 +121,3 @@ main()
   return printTestStats();
 
 }
-

--- a/test/posix_time/testmicrosec_time_clock.cpp
+++ b/test/posix_time/testmicrosec_time_clock.cpp
@@ -45,12 +45,11 @@ main()
 
   using namespace boost::posix_time;
 
-  //  ptime last = boost::date_time::microsec_resolution_clock<ptime>::local_time();
-  ptime last = microsec_clock::local_time();
+  std::cout << "Check local time of microsec_clock against second_clock" << std::endl;
 
+  ptime last = microsec_clock::local_time();
   int max = 30;
-  int i = 0;
-  for (i = 0; i<max; i++)
+  for (int i=0; i<max; i++)
   {
     // Some systems loop too fast so "last is less" tests fail due to
     // 'last' & 't2' being equal. These calls slow it down enough to
@@ -65,26 +64,36 @@ main()
     ptime t2 = microsec_clock::local_time();
     std::cout << to_simple_string(t2) << std::endl;
 
-    check("hours match", t1.time_of_day().hours() == t2.time_of_day().hours());
-    check("minutes match",
+    check("check equality of hours "
+          "between second_clock and microsec_clock timestamps",
+          t1.time_of_day().hours() == t2.time_of_day().hours());
+
+    check("check equality of minutes "
+          "between second_clock and microsec_clock timestamps",
           t1.time_of_day().minutes() == t2.time_of_day().minutes());
-    check("seconds match",
+
+    check("check equality of seconds "
+          "between second_clock and microsec_clock timestamps",
           t1.time_of_day().seconds() == t2.time_of_day().seconds());
-    check("hours date", t1.date() == t2.date());
-    if( !check("last is less", last <= t2) ) {
+
+    check("check equality of date"
+          "between second_clock and microsec_clock timestamps",
+          t1.date() == t2.date());
+
+    if( !check("check that previous microsec_clock timestamp "
+               "is less than the current", last < t2) ) {
       std::cout << to_simple_string(last) << " < "
-        << to_simple_string(t2) << std::endl;
+                << to_simple_string(t2) << std::endl;
     }
+
     last = t2;
-
-
   }
 
 
-  std::cout << "Now do the same test for universal time -- a few less iterations" << std::endl;
+  std::cout << "Check universal time of microsec_clock against second_clock" << std::endl;
   max = 10;
   last = microsec_clock::universal_time();
-  for (i = 0; i<max; i++)
+  for (int i=0; i<max; i++)
   {
     // Some systems loop too fast so "last is less" tests fail due to
     // 'last' & 't2' being equal. These calls slow it down enough to
@@ -99,20 +108,29 @@ main()
     ptime t2 = microsec_clock::universal_time();
     std::cout << to_simple_string(t2) << std::endl;
 
-    check("hours match", t1.time_of_day().hours() == t2.time_of_day().hours());
-    check("minutes match",
+    check("check equality of hours "
+          "between second_clock and microsec_clock timestamps",
+          t1.time_of_day().hours() == t2.time_of_day().hours());
+
+    check("check equality of minutes "
+          "between second_clock and microsec_clock timestamps",
           t1.time_of_day().minutes() == t2.time_of_day().minutes());
-    check("seconds match",
+
+    check("check equality of seconds "
+          "between second_clock and microsec_clock timestamps",
           t1.time_of_day().seconds() == t2.time_of_day().seconds());
-    check("hours date", t1.date() == t2.date());
-    //following check might be equal on a really fast machine
-    if( !check("last is less", last <= t2) ) {
+
+    check("check equality of date"
+          "between second_clock and microsec_clock timestamps",
+          t1.date() == t2.date());
+
+    if( !check("check that previous microsec_clock timestamp "
+               "is less than the current", last < t2) ) {
       std::cout << to_simple_string(last) << " < "
-        << to_simple_string(t2) << std::endl;
+                << to_simple_string(t2) << std::endl;
     }
+
     last = t2;
-
-
   }
 
 #else


### PR DESCRIPTION
The aim is to avoid false positives in test_microsec when the seconds,
minutes or hours change during time read between the second_clock and
the microsec_clock.