### PR TITLE
Add time_duration helper functions:

### DIFF
--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -144,9 +144,25 @@ namespace date_time {
     {
       return duration_type(ticks_ * (-1));
     }
+    duration_type abs() const
+    {
+      if ( is_negative() )
+      {
+        return invert_sign();
+      }
+      return duration_type(ticks_);
+    }
     bool is_negative() const
     {
       return ticks_ < 0;
+    }
+    bool is_zero() const
+    {
+      return ticks_ == 0;
+    }
+    bool is_positive() const
+    {
+      return ticks_ > 0;
     }
     bool operator<(const time_duration& rhs)  const
     {

--- a/test/posix_time/testduration.cpp
+++ b/test/posix_time/testduration.cpp
@@ -35,8 +35,18 @@ main()
   time_duration td3(td1.hours(),td1.minutes(),td1.seconds());
   check("total up elements", td1 == td3);
   td1 = -td1; // td1 == "-1:25:00"
+  check("invert_sign",td3 == td1.invert_sign());
+  check("invert_sign",td1 == td3.invert_sign());
+  check("abs",td3 == td1.abs());
+  check("abs",td3 == td3.abs());
+  check("is_positive",td3.is_positive());
+  check("is_positive",!td1.is_positive());
+  check("is_negative",td1.is_negative());
+  check("is_negative",!td3.is_negative());
+  check("is_zero",!td1.is_zero());
+  check("is_zero",(td1 - td1).is_zero());
   td3 = time_duration(td1.hours(),td1.minutes(),td1.seconds());
-  check("total up elements-invered sign", td1 == td3);
+  check("total up elements-inverted sign", td1 == td3);
   
   
   time_duration t_1(0,1,40);

--- a/xmldoc/time_duration.xml
+++ b/xmldoc/time_duration.xml
@@ -256,7 +256,7 @@ neg_td.minutes(); // --> -2</screen></entry>
         </row>
         
 	  <row>
-	    <entry valign="top" morerows="1"><screen>boost::int64_t seconds()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>boost::int64_t seconds() const</screen></entry>
             <entry>Get the normalized number of second +/-(0..59) (will give unpredictable results if calling <code>time_duration</code> is a <code>special_value</code>).</entry>
 	  </row>
 	  <row>
@@ -267,7 +267,7 @@ neg_td.seconds(); // --> -3</screen></entry>
         </row>
         
 	  <row>
-	    <entry valign="top" morerows="1"><screen>boost::int64_t total_seconds()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>boost::int64_t total_seconds() const</screen></entry>
 	    <entry>Get the total number of seconds truncating any fractional seconds (will give unpredictable results if calling <code>time_duration</code> is a <code>special_value</code>).</entry>
 	  </row>
 	  <row>
@@ -278,7 +278,7 @@ td.total_seconds();
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>boost::int64_t total_milliseconds()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>boost::int64_t total_milliseconds() const</screen></entry>
 	    <entry>Get the total number of milliseconds truncating any remaining digits (will give unpredictable results if calling <code>time_duration</code> is a <code>special_value</code>).</entry>
 	  </row>
 	  <row>
@@ -291,7 +291,7 @@ td.total_milliseconds();
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>boost::int64_t total_microseconds()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>boost::int64_t total_microseconds() const</screen></entry>
 	    <entry>Get the total number of microseconds truncating any remaining digits (will give unpredictable results if calling <code>time_duration</code> is a <code>special_value</code>).</entry>
 	  </row>
 	  <row>
@@ -304,7 +304,7 @@ td.total_microseconds();
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>boost::int64_t total_nanoseconds()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>boost::int64_t total_nanoseconds() const</screen></entry>
 	    <entry>Get the total number of nanoseconds truncating any remaining digits (will give unpredictable results if calling <code>time_duration</code> is a <code>special_value</code>).</entry>
 	  </row>
 	  <row>
@@ -318,7 +318,7 @@ td.total_nanoseconds();
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>boost::int64_t fractional_seconds()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>boost::int64_t fractional_seconds() const</screen></entry>
 	    <entry>Get the number of fractional seconds (will give unpredictable results if calling <code>time_duration</code> is a <code>special_value</code>).</entry>
 	  </row>
 	  <row>
@@ -327,8 +327,8 @@ td.fractional_seconds(); // --> 1000</screen></entry>
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>bool is_negative()</screen></entry>
-	    <entry>True if duration is negative.</entry>
+	    <entry valign="top" morerows="1"><screen>bool is_negative() const</screen></entry>
+	    <entry>True if and only if duration is negative.</entry>
 	  </row>
 	  <row>
             <entry><screen>time_duration td(-1,0,0); 
@@ -336,16 +336,45 @@ td.is_negative(); // --> true</screen></entry>
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>time_duration invert_sign()</screen></entry>
-	    <entry>Generate a new duration with the sign inverted/</entry>
+	    <entry valign="top" morerows="1"><screen>bool is_zero() const</screen></entry>
+	    <entry>True if and only if duration is zero.</entry>
 	  </row>
 	  <row>
-            <entry><screen>time_duration td(-1,0,0); 
+            <entry><screen>time_duration td(0,0,0);
+td.is_zero(); // --> true</screen></entry>
+          </row>
+
+	  <row>
+	    <entry valign="top" morerows="1"><screen>bool is_positive() const</screen></entry>
+	    <entry>True if and only if duration is positive.</entry>
+	  </row>
+	  <row>
+            <entry><screen>time_duration td(1,0,0);
+td.is_positive(); // --> true</screen></entry>
+          </row>
+
+	  <row>
+	    <entry valign="top" morerows="1"><screen>time_duration invert_sign() const</screen></entry>
+	    <entry>Generate a new duration with the sign inverted.</entry>
+	  </row>
+	  <row>
+            <entry><screen>time_duration td(-1,0,0);
 td.invert_sign(); // --> 01:00:00</screen></entry>
           </row>
           
 	  <row>
-	    <entry valign="top" morerows="1"><screen>date_time::time_resolutions resolution()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>time_duration abs() const</screen></entry>
+	    <entry>Generate a new duration with the absolute value of the time duration.</entry>
+	  </row>
+	  <row>
+            <entry><screen>time_duration td(-1,0,0);
+td.abs(); // --> 01:00:00</screen></entry>
+            <entry><screen>time_duration td(+1,0,0);
+td.abs(); // --> 01:00:00</screen></entry>
+          </row>
+
+	  <row>
+	    <entry valign="top" morerows="1"><screen>date_time::time_resolutions time_duration::resolution()</screen></entry>
             <entry>Describes the resolution capability of the time_duration class. time_resolutions is an enum of resolution possibilities ranging from seconds to nanoseconds.</entry>
 	  </row>
 	  <row>
@@ -353,8 +382,8 @@ td.invert_sign(); // --> 01:00:00</screen></entry>
           </row>
           
 	  <row>
-            <entry valign="top" morerows="1"><screen>time_duration::num_fractional_digits()</screen></entry>
-            <entry>Returns an unsigned short holding the number of fractional digits the time resolution has.</entry>
+            <entry valign="top" morerows="1"><screen>unsigned short time_duration::num_fractional_digits()</screen></entry>
+            <entry>Returns the number of fractional digits the time resolution has.</entry>
 	  </row>
 	  <row>
             <entry><screen>unsigned short secs;
@@ -363,7 +392,7 @@ secs = time_duration::num_fractional_digits();
           </row>
           
 	  <row>
-            <entry valign="top" morerows="1"><screen>time_duration::ticks_per_second()</screen></entry>
+            <entry valign="top" morerows="1"><screen>boost::int64_t time_duration::ticks_per_second()</screen></entry>
             <entry>Return the number of ticks in a second.  For example, if the duration supports nanoseconds then the returned result will be 1,000,000,000 (1e+9).</entry>
 	  </row>
 	  <row>
@@ -380,7 +409,7 @@ td.ticks() // --> 1000</screen></entry>
           </row>
           
           <row>
-	    <entry valign="top" morerows="1"><screen>time_duration unit()</screen></entry>
+	    <entry valign="top" morerows="1"><screen>time_duration time_duration::unit()</screen></entry>
 	    <entry>Return smallest possible unit of duration type (1 nanosecond).</entry>
 	  </row>
 	  <row>


### PR DESCRIPTION
1. is_positive()
  - Return boolean value to indicate whether or not time duration is
    positive.
2. is_zero()
  - Return boolean value to indicate whether or not time duration is
    zero.
3. abs()
  - Return a time_duration which is the absolute value of time
    duration.

Added documentation for these helper functions and improved existing
documentation to indicate constness, return values or static
functions.