### PR TITLE
Force inline boost::gregorian::date::date(special_values) to improve performance

### DIFF
--- a/include/boost/date_time/gregorian/greg_date.hpp
+++ b/include/boost/date_time/gregorian/greg_date.hpp
@@ -73,7 +73,7 @@ namespace gregorian {
       date_time::date<date,gregorian_calendar, date_duration>(rhs)
     {}
     //! Constructor for infinities, not a date, max and min date
-    explicit date(special_values sv):
+    BOOST_FORCEINLINE explicit date(special_values sv):
       date_time::date<date, gregorian_calendar, date_duration>(date_rep_type::from_special(sv))
     {
       if (sv == min_date_time)


### PR DESCRIPTION
Fixes #121 

A small overview of benefits and potential downsides is extracted from #121 below:

This compiler workaround would improve the code size and speed for the majority of user workloads that are affected.

The only possibility this could be a regression would be in rarely executed call sites that pass non-constant value of special_values directly or indirectly to boost::gregorian::date::date. However, forcing inlining in such a case would just inflate code size a little bit and I suspect that the library user would still save code size overall due to significant reductions of code size around calls to default constructor of ptime and related types.

In my case the performance of whole application has been improved by around 5%.
 
