### PR TITLE
suppressed const qualifier on function return type

### DIFF
--- a/include/boost/date_time/gregorian/greg_weekday.hpp
+++ b/include/boost/date_time/gregorian/greg_weekday.hpp
@@ -49,7 +49,7 @@ namespace gregorian {
     BOOST_CXX14_CONSTEXPR weekday_enum as_enum() const {return static_cast<weekday_enum>(value_);}
 
       //! Return a 3 digit english string of the day of week (eg: Sun)
-    const char* const as_short_string() const
+    const char* as_short_string() const
     {
       static const char* const short_weekday_names[]=
 	{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
@@ -58,7 +58,7 @@ namespace gregorian {
     }
 
     //! Return a point to a long english string representing day of week
-    const char* const as_long_string() const
+    const char* as_long_string() const
     {
       static const char* const long_weekday_names[]
 	= {"Sunday","Monday","Tuesday","Wednesday", "Thursday", "Friday", "Saturday"};

--- a/include/boost/date_time/gregorian/greg_weekday.hpp
+++ b/include/boost/date_time/gregorian/greg_weekday.hpp
@@ -48,7 +48,7 @@ namespace gregorian {
     BOOST_CXX14_CONSTEXPR value_type as_number() const {return value_;}
     BOOST_CXX14_CONSTEXPR weekday_enum as_enum() const {return static_cast<weekday_enum>(value_);}
 
-      //! Return a 3 digit english string of the day of week (eg: Sun)
+    //! Return a 3 digit english string of the day of week (eg: Sun)
     const char* as_short_string() const
     {
       static const char* const short_weekday_names[]=


### PR DESCRIPTION
As warned in https://www.boost.org/development/tests/develop/output/teeks99-dkr-dg4-6-warn-date_time-gcc-4-6~c++0x~warn-warnings.html#hours_special_value :
```
../boost/date_time/gregorian/greg_weekday.hpp:52:41: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
../boost/date_time/gregorian/greg_weekday.hpp:61:40: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
```