### PR TITLE
Add missing includes and fix special_value_from_string definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,30 +113,31 @@ jobs:
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
         - B2_LINKFLAGS="linkflags=-fuse-ld=gold"
         - UBSAN_OPTIONS=print_stacktrace=1
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
 
   include:
     # libstdc++
     - { os: "linux", dist: "trusty",  # xenial has libstdc++ from gcc 5.4.0 with newer ABI
-                     env: [ "B2_TOOLSET=gcc-4.8",     "B2_CXXSTD=03,11"    ], addons: *gcc-48    }
+                     env: [ "B2_TOOLSET=gcc-4.8",     "B2_CXXSTD=03,11",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *gcc-48    }
     - { os: "linux", dist: "trusty",  # xenial has libstdc++ from gcc 5.4.0 with newer ABI
-                     env: [ "B2_TOOLSET=gcc-4.9",     "B2_CXXSTD=03,11"    ], addons: *gcc-49    }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-5",       "B2_CXXSTD=03,11"    ], addons: *gcc-5     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-6",       "B2_CXXSTD=11,14"    ], addons: *gcc-6     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=14,17"    ], addons: *gcc-7     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-8",       "B2_CXXSTD=17,2a"    ], addons: *gcc-8     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-9",       "B2_CXXSTD=17,2a"    ], addons: *gcc-9     }
+                     env: [ "B2_TOOLSET=gcc-4.9",     "B2_CXXSTD=03,11",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *gcc-49    }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-5",       "B2_CXXSTD=03,11"                                                                  ], addons: *gcc-5     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-6",       "B2_CXXSTD=11,14",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *gcc-6     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=14,17",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *gcc-7     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-8",       "B2_CXXSTD=17,2a",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *gcc-8     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-9",       "B2_CXXSTD=17,2a",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *gcc-9     }
     - { os: "linux", dist: "trusty",  # xenial has libstdc++ from gcc 5.4.0 with newer ABI
-                     env: [ "B2_TOOLSET=clang-3.8",   "B2_CXXSTD=03,11"    ], addons: *clang-38  }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-4.0",   "B2_CXXSTD=11,14"    ], addons: *clang-4   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-5.0",   "B2_CXXSTD=11,14"    ], addons: *clang-5   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=14,17"    ], addons: *clang-6   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-7",     "B2_CXXSTD=17,2a"    ], addons: *clang-7   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-8",     "B2_CXXSTD=17,2a"    ], addons: *clang-8   }
+                     env: [ "B2_TOOLSET=clang-3.8",   "B2_CXXSTD=03,11",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *clang-38  }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-4.0",   "B2_CXXSTD=11,14",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *clang-4   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-5.0",   "B2_CXXSTD=11,14",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *clang-5   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=14,17",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *clang-6   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-7",     "B2_CXXSTD=17,2a",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *clang-7   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-8",     "B2_CXXSTD=17,2a",    "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ], addons: *clang-8   }
 
     # libc++
     - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=03,11,14",
                             "B2_CXXFLAGS=-stdlib=libc++"                   ], addons: *clang-6   }
-    - { os: "osx"  , env: [ "B2_TOOLSET=clang",       "B2_CXXSTD=03,11,17" ]                     }
+    - { os: "osx"  , env: [ "B2_TOOLSET=clang",       "B2_CXXSTD=03,11,17", "BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1" ]                     }
 
     # to enable Intel ICC define INTEL_ICC_SERIAL_NUMBER and the following:
     # - { os: "linux", env: [ "B2_TOOLSET=intel-linux", "B2_CXXSTD=11,14,17" ], addons: *gcc-7,
@@ -148,6 +149,7 @@ jobs:
         - B2_CXXSTD=03,11
         - B2_TOOLSET=gcc-8
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
       addons: *gcc-8
       script:
         - cd $BOOST_ROOT/libs/$SELF
@@ -161,6 +163,7 @@ jobs:
         - B2_CXXSTD=03,11,14
         - B2_CXXFLAGS="address-sanitizer=norecover"
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
       addons: *gcc-8
 
     - os: linux
@@ -171,6 +174,7 @@ jobs:
         - B2_CXXSTD=03,11,14
         - B2_CXXFLAGS="thread-sanitizer=norecover"
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
       addons: *gcc-8
 
     - os: linux
@@ -184,6 +188,7 @@ jobs:
         # https://github.com/boostorg/build/issues/451 using the gold linker to work around an issue
         - B2_LINKFLAGS="linkflags=-fuse-ld=gold"
         - UBSAN_OPTIONS=print_stacktrace=1
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
       addons: *gcc-8
 
     - os: linux
@@ -194,6 +199,7 @@ jobs:
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
         - B2_VARIANT=variant=debug
         - B2_TESTFLAGS=testing.launcher=valgrind
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
         - VALGRIND_OPTS=--error-exitcode=1
       addons: *clang-6
       script:
@@ -215,6 +221,7 @@ jobs:
       env:
         - COMMENT="Coverity Scan"
         - B2_TOOLSET=clang
+        - BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS=1
       script:
         - cd $BOOST_ROOT/libs/$SELF
         - ci/travis/coverity.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,7 @@ environment:
       B2_CXXFLAGS: cxxflags=-permissive-
       B2_CXXSTD: latest # 2a
       B2_TOOLSET: msvc-14.1
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: Visual Studio 2017 C++17
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -69,27 +70,32 @@ environment:
       B2_CXXSTD: 17
       B2_TOOLSET: msvc-14.1
       B2_VARIANT: variant=debug
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: Visual Studio 2017 C++14 (Default)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       B2_ADDRESS_MODEL: address-model=64,32
       B2_TOOLSET: msvc-14.1
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: clang-cl
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       B2_ADDRESS_MODEL: address-model=64
       B2_CXXSTD: 11
       B2_TOOLSET: clang-win
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: Visual Studio 2015 C++14 (Default)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_ADDRESS_MODEL: address-model=64,32
       B2_TOOLSET: msvc-14.0
       B2_VARIANT: variant=debug
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: Visual Studio 2010, 2012, 2013
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_TOOLSET: msvc-10.0,msvc-11.0,msvc-12.0
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -101,6 +107,7 @@ environment:
       B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
       B2_VARIANT: variant=debug
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: cygwin (64-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -111,6 +118,7 @@ environment:
       B2_DEFINES: define=_POSIX_C_SOURCE=200112L define=__USE_ISOC99
       B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: mingw32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -119,6 +127,7 @@ environment:
       B2_CXXSTD: 03,11
       SCRIPT: ci\appveyor\mingw.bat
       B2_VARIANT: variant=debug
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
     - FLAVOR: mingw64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -127,6 +136,7 @@ environment:
       B2_CXXSTD: 11,17
       B2_DEFINES: define=__USE_ISOC99
       SCRIPT: ci\appveyor\mingw.bat
+      BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS: 1
 
 install:
   - set SELF=%APPVEYOR_PROJECT_NAME:-=_%

--- a/include/boost/date_time/date_duration.hpp
+++ b/include/boost/date_time/date_duration.hpp
@@ -13,6 +13,7 @@
 #include <boost/operators.hpp>
 #include <boost/date_time/special_defs.hpp>
 #include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/int_adapter.hpp>
 
 namespace boost {
 namespace date_time {

--- a/include/boost/date_time/date_generators.hpp
+++ b/include/boost/date_time/date_generators.hpp
@@ -157,7 +157,7 @@ namespace date_time {
   inline const char* nth_as_str(int ele)
   {
     static const char* const _nth_as_str[] = {"out of range", "first", "second",
-					      "third", "fourth", "fifth"};
+                                              "third", "fourth", "fifth"};
     if(ele >= 1 && ele <= 5) {
       return _nth_as_str[ele];
     }

--- a/include/boost/date_time/date_parsing.hpp
+++ b/include/boost/date_time/date_parsing.hpp
@@ -9,13 +9,16 @@
  * $Date$
  */
 
+#include <map>
 #include <string>
+#include <sstream>
 #include <iterator>
 #include <algorithm>
 #include <boost/tokenizer.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/date_time/compiler_config.hpp>
 #include <boost/date_time/parse_format_base.hpp>
+#include <boost/date_time/period.hpp>
 
 #if defined(BOOST_DATE_TIME_NO_LOCALE)
 #include <cctype> // ::tolower(int)
@@ -62,54 +65,54 @@ namespace date_time {
       }
       else {
         std::string str = convert_to_lower(s);
-	//c++98 support
+        //c++98 support
 #if defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX)
-	static std::map<std::string, unsigned short> month_map;
-	typedef std::map<std::string, unsigned short>::value_type vtype;
-	if( month_map.empty() ) {
-	  month_map.insert( vtype("jan", static_cast<unsigned short>(1)) );
-	  month_map.insert( vtype("january", static_cast<unsigned short>(1)) );
-	  month_map.insert( vtype("feb", static_cast<unsigned short>(2)) );
-	  month_map.insert( vtype("february", static_cast<unsigned short>(2)) );
-	  month_map.insert( vtype("mar", static_cast<unsigned short>(3)) );
-	  month_map.insert( vtype("march", static_cast<unsigned short>(3)) );
-	  month_map.insert( vtype("apr", static_cast<unsigned short>(4)) );
-	  month_map.insert( vtype("april", static_cast<unsigned short>(4)) );
-	  month_map.insert( vtype("may", static_cast<unsigned short>(5)) );
-	  month_map.insert( vtype("jun", static_cast<unsigned short>(6)) );
-	  month_map.insert( vtype("june", static_cast<unsigned short>(6)) );
-	  month_map.insert( vtype("jul", static_cast<unsigned short>(7)) );
-	  month_map.insert( vtype("july", static_cast<unsigned short>(7)) );
-	  month_map.insert( vtype("aug", static_cast<unsigned short>(8)) );
-	  month_map.insert( vtype("august", static_cast<unsigned short>(8)) );
-	  month_map.insert( vtype("sep", static_cast<unsigned short>(9)) );
-	  month_map.insert( vtype("september", static_cast<unsigned short>(9)) );
-	  month_map.insert( vtype("oct", static_cast<unsigned short>(10)) );
-	  month_map.insert( vtype("october", static_cast<unsigned short>(10)) );
-	  month_map.insert( vtype("nov", static_cast<unsigned short>(11)) );
-	  month_map.insert( vtype("november", static_cast<unsigned short>(11)) );
-	  month_map.insert( vtype("dec", static_cast<unsigned short>(12)) );
-	  month_map.insert( vtype("december", static_cast<unsigned short>(12)) );
-	}
+        static std::map<std::string, unsigned short> month_map;
+        typedef std::map<std::string, unsigned short>::value_type vtype;
+        if( month_map.empty() ) {
+          month_map.insert( vtype("jan", static_cast<unsigned short>(1)) );
+          month_map.insert( vtype("january", static_cast<unsigned short>(1)) );
+          month_map.insert( vtype("feb", static_cast<unsigned short>(2)) );
+          month_map.insert( vtype("february", static_cast<unsigned short>(2)) );
+          month_map.insert( vtype("mar", static_cast<unsigned short>(3)) );
+          month_map.insert( vtype("march", static_cast<unsigned short>(3)) );
+          month_map.insert( vtype("apr", static_cast<unsigned short>(4)) );
+          month_map.insert( vtype("april", static_cast<unsigned short>(4)) );
+          month_map.insert( vtype("may", static_cast<unsigned short>(5)) );
+          month_map.insert( vtype("jun", static_cast<unsigned short>(6)) );
+          month_map.insert( vtype("june", static_cast<unsigned short>(6)) );
+          month_map.insert( vtype("jul", static_cast<unsigned short>(7)) );
+          month_map.insert( vtype("july", static_cast<unsigned short>(7)) );
+          month_map.insert( vtype("aug", static_cast<unsigned short>(8)) );
+          month_map.insert( vtype("august", static_cast<unsigned short>(8)) );
+          month_map.insert( vtype("sep", static_cast<unsigned short>(9)) );
+          month_map.insert( vtype("september", static_cast<unsigned short>(9)) );
+          month_map.insert( vtype("oct", static_cast<unsigned short>(10)) );
+          month_map.insert( vtype("october", static_cast<unsigned short>(10)) );
+          month_map.insert( vtype("nov", static_cast<unsigned short>(11)) );
+          month_map.insert( vtype("november", static_cast<unsigned short>(11)) );
+          month_map.insert( vtype("dec", static_cast<unsigned short>(12)) );
+          month_map.insert( vtype("december", static_cast<unsigned short>(12)) );
+        }
 #else  //c+11 and beyond
-	static std::map<std::string, unsigned short> month_map =
-	  { { "jan", 1 },  { "january", 1 },
-	    { "feb", 2 },  { "february", 2 },
-	    { "mar", 3 },  { "march", 3 },
-	    { "apr", 4 },  { "april", 4 },
-	    { "may", 5 },
-	    { "jun", 6 },  { "june", 6 },
-	    { "jul", 7 },  { "july", 7 },
-	    { "aug", 8 },  { "august", 8 },
-	    { "sep", 9 },  { "september", 9 },
-	    { "oct", 10 }, { "october", 10 },
-	    { "nov", 11 }, { "november", 11 },
-	    { "dec", 12 }, { "december", 12 }
-	  };
+        static std::map<std::string, unsigned short> month_map =
+          { { "jan", 1 },  { "january", 1 },
+            { "feb", 2 },  { "february", 2 },
+            { "mar", 3 },  { "march", 3 },
+            { "apr", 4 },  { "april", 4 },
+            { "may", 5 },
+            { "jun", 6 },  { "june", 6 },
+            { "jul", 7 },  { "july", 7 },
+            { "aug", 8 },  { "august", 8 },
+            { "sep", 9 },  { "september", 9 },
+            { "oct", 10 }, { "october", 10 },
+            { "nov", 11 }, { "november", 11 },
+            { "dec", 12 }, { "december", 12 }
+          };
 #endif
-	std::map<std::string, unsigned short>::const_iterator mitr = month_map.find( str );
-	if ( mitr !=  month_map.end() ) {
-	  return mitr->second;
+        std::map<std::string, unsigned short>::const_iterator mitr = month_map.find( str );
+        if ( mitr !=  month_map.end() ) {
+          return mitr->second;
         }
       }
       return 13; // intentionally out of range - name not found

--- a/include/boost/date_time/dst_rules.hpp
+++ b/include/boost/date_time/dst_rules.hpp
@@ -2,7 +2,7 @@
 #define DATE_TIME_DST_RULES_HPP__
 
 /* Copyright (c) 2002,2003, 2007 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
@@ -21,12 +21,12 @@
 namespace boost {
   namespace date_time {
 
-    enum time_is_dst_result {is_not_in_dst, is_in_dst, 
+    enum time_is_dst_result {is_not_in_dst, is_in_dst,
                              ambiguous, invalid_time_label};
 
 
     //! Dynamic class used to caluclate dst transition information
-    template<class date_type_, 
+    template<class date_type_,
              class time_duration_type_>
     class dst_calculator
     {
@@ -37,14 +37,14 @@ namespace boost {
       //! Check the local time offset when on dst start day
       /*! On this dst transition, the time label between
        *  the transition boundary and the boudary + the offset
-       *  are invalid times.  If before the boundary then still 
-       *  not in dst.  
+       *  are invalid times.  If before the boundary then still
+       *  not in dst.
        *@param time_of_day Time offset in the day for the local time
        *@param dst_start_offset_minutes Local day offset for start of dst
        *@param dst_length_minutes Number of minutes to adjust clock forward
        *@retval status of time label w.r.t. dst
        */
-      static time_is_dst_result 
+      static time_is_dst_result
       process_local_dst_start_day(const time_duration_type& time_of_day,
                                   unsigned int dst_start_offset_minutes,
                                   long dst_length_minutes)
@@ -57,19 +57,19 @@ namespace boost {
         if (time_of_day >= time_duration_type(0,offset,0)) {
           return is_in_dst;
         }
-        return invalid_time_label; 
+        return invalid_time_label;
       }
 
       //! Check the local time offset when on the last day of dst
       /*! This is the calculation for the DST end day.  On that day times
-       *  prior to the conversion time - dst_length (1 am in US) are still 
-       *  in dst.  Times between the above and the switch time are 
+       *  prior to the conversion time - dst_length (1 am in US) are still
+       *  in dst.  Times between the above and the switch time are
        *  ambiguous.  Times after the start_offset are not in dst.
        *@param time_of_day Time offset in the day for the local time
        *@param dst_end_offset_minutes Local time of day for end of dst
        *@retval status of time label w.r.t. dst
        */
-      static time_is_dst_result 
+      static time_is_dst_result
       process_local_dst_end_day(const time_duration_type& time_of_day,
                                 unsigned int dst_end_offset_minutes,
                                 long dst_length_minutes)
@@ -86,10 +86,10 @@ namespace boost {
       }
 
       //! Calculates if the given local time is dst or not
-      /*! Determines if the time is really in DST or not.  Also checks for 
+      /*! Determines if the time is really in DST or not.  Also checks for
        *  invalid and ambiguous.
        *  @param current_day The day to check for dst
-       *  @param time_of_day Time offset within the day to check 
+       *  @param time_of_day Time offset within the day to check
        *  @param dst_start_day  Starting day of dst for the given locality
        *  @param dst_start_offset Time offset within day for dst boundary
        *  @param dst_end_day    Ending day of dst for the given locality
@@ -97,7 +97,7 @@ namespace boost {
        *  @param dst_length_minutes length of dst adjusment
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
-      static time_is_dst_result 
+      static time_is_dst_result
       local_is_dst(const date_type& current_day,
                    const time_duration_type& time_of_day,
                    const date_type& dst_start_day,
@@ -120,20 +120,20 @@ namespace boost {
       }
 
       //! Calculates if the given local time is dst or not
-      /*! Determines if the time is really in DST or not.  Also checks for 
+      /*! Determines if the time is really in DST or not.  Also checks for
        *  invalid and ambiguous.
        *  @param current_day The day to check for dst
-       *  @param time_of_day Time offset within the day to check 
+       *  @param time_of_day Time offset within the day to check
        *  @param dst_start_day  Starting day of dst for the given locality
-       *  @param dst_start_offset_minutes Offset within day for dst 
+       *  @param dst_start_offset_minutes Offset within day for dst
        *         boundary (eg 120 for US which is 02:00:00)
        *  @param dst_end_day    Ending day of dst for the given locality
-       *  @param dst_end_offset_minutes Offset within day given in dst for dst 
+       *  @param dst_end_offset_minutes Offset within day given in dst for dst
        *         boundary (eg 120 for US which is 02:00:00)
        *  @param dst_length_minutes Length of dst adjusment (eg: 60 for US)
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
-      static time_is_dst_result 
+      static time_is_dst_result
       local_is_dst(const date_type& current_day,
                    const time_duration_type& time_of_day,
                    const date_type& dst_start_day,
@@ -165,7 +165,7 @@ namespace boost {
                                              dst_start_offset_minutes,
                                              dst_length_minutes);
         }
-      
+
         if (current_day == dst_end_day) {
           return process_local_dst_end_day(time_of_day,
                                            dst_end_offset_minutes,
@@ -183,29 +183,29 @@ namespace boost {
      * calculation at compile time covering all the cases.  Unfortunately
      * because of the number of dimensions related to daylight savings
      * calculation the number of parameters is high.  In addition, the
-     * start and end transition rules are complex types that specify 
+     * start and end transition rules are complex types that specify
      * an algorithm for calculation of the starting day and ending
-     * day of daylight savings time including the month and day 
+     * day of daylight savings time including the month and day
      * specifications (eg: last sunday in October).
      *
      * @param date_type A type that represents dates, typically gregorian::date
      * @param time_duration_type Used for the offset in the day calculations
-     * @param dst_traits A set of traits that define the rules of dst 
+     * @param dst_traits A set of traits that define the rules of dst
      *        calculation.  The dst_trait must include the following:
      * start_rule_functor - Rule to calculate the starting date of a
      *                      dst transition (eg: last_kday_of_month).
-     * start_day - static function that returns month of dst start for 
+     * start_day - static function that returns month of dst start for
      *             start_rule_functor
-     * start_month -static function that returns day or day of week for 
+     * start_month -static function that returns day or day of week for
      *              dst start of dst
      * end_rule_functor - Rule to calculate the end of dst day.
      * end_day - static fucntion that returns end day for end_rule_functor
      * end_month - static function that returns end month for end_rule_functor
      * dst_start_offset_minutes - number of minutes from start of day to transition to dst -- 120 (or 2:00 am) is typical for the U.S. and E.U.
-     * dst_start_offset_minutes - number of minutes from start of day to transition off of dst -- 180 (or 3:00 am) is typical for E.U. 
+     * dst_start_offset_minutes - number of minutes from start of day to transition off of dst -- 180 (or 3:00 am) is typical for E.U.
      * dst_length_minutes - number of minutes that dst shifts clock
      */
-    template<class date_type, 
+    template<class date_type,
              class time_duration_type,
              class dst_traits>
     class dst_calc_engine
@@ -216,12 +216,12 @@ namespace boost {
       typedef dst_calculator<date_type, time_duration_type> dstcalc;
 
       //! Calculates if the given local time is dst or not
-      /*! Determines if the time is really in DST or not.  Also checks for 
+      /*! Determines if the time is really in DST or not.  Also checks for
        *  invalid and ambiguous.
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
       static time_is_dst_result local_is_dst(const date_type& d,
-                                             const time_duration_type& td) 
+                                             const time_duration_type& td)
       {
 
         year_type y = d.year();
@@ -230,10 +230,10 @@ namespace boost {
         return dstcalc::local_is_dst(d,td,
                                      dst_start,
                                      dst_traits::dst_start_offset_minutes(),
-                                     dst_end, 
-                                     dst_traits::dst_end_offset_minutes(), 
+                                     dst_end,
+                                     dst_traits::dst_end_offset_minutes(),
                                      dst_traits::dst_shift_length_minutes());
-      
+
       }
 
       static bool is_dst_boundary_day(date_type d)
@@ -244,14 +244,14 @@ namespace boost {
       }
 
       //! The time of day for the dst transition (eg: typically 01:00:00 or 02:00:00)
-      static time_duration_type dst_offset() 
+      static time_duration_type dst_offset()
       {
         return time_duration_type(0,dst_traits::dst_shift_length_minutes(),0);
       }
 
       static date_type local_dst_start_day(year_type year)
       {
-        return dst_traits::local_dst_start_day(year);      
+        return dst_traits::local_dst_start_day(year);
       }
 
       static date_type local_dst_end_day(year_type year)
@@ -267,11 +267,11 @@ namespace boost {
      * In 2007 US/Canada DST rules changed
      * (http://en.wikipedia.org/wiki/Energy_Policy_Act_of_2005#Change_to_daylight_saving_time).
      */
-    template<class date_type_, 
+    template<class date_type_,
              class time_duration_type_,
-             unsigned int dst_start_offset_minutes=120, //from start of day 
+             unsigned int dst_start_offset_minutes=120, //from start of day
              short dst_length_minutes=60>  //1 hour == 60 min in US
-    class us_dst_rules 
+    class us_dst_rules
     {
     public:
       typedef time_duration_type_ time_duration_type;
@@ -284,12 +284,12 @@ namespace boost {
       typedef dst_calculator<date_type, time_duration_type> dstcalc;
 
       //! Calculates if the given local time is dst or not
-      /*! Determines if the time is really in DST or not.  Also checks for 
+      /*! Determines if the time is really in DST or not.  Also checks for
        *  invalid and ambiguous.
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
       static time_is_dst_result local_is_dst(const date_type& d,
-                                             const time_duration_type& td) 
+                                             const time_duration_type& td)
       {
 
         year_type y = d.year();
@@ -297,9 +297,9 @@ namespace boost {
         date_type dst_end   = local_dst_end_day(y);
         return dstcalc::local_is_dst(d,td,
                                      dst_start,dst_start_offset_minutes,
-                                     dst_end, dst_start_offset_minutes, 
+                                     dst_end, dst_start_offset_minutes,
                                      dst_length_minutes);
-      
+
       }
 
 
@@ -314,12 +314,12 @@ namespace boost {
       {
         if (year >= year_type(2007)) {
           //second sunday in march
-          nkday ssim(nkday::second, Sunday, gregorian::Mar);
-          return ssim.get_date(year);      
+          nkday ssim(nkday::second, Sunday, date_time::Mar);
+          return ssim.get_date(year);
         } else {
           //first sunday in april
-          fkday fsia(Sunday, gregorian::Apr);
-          return fsia.get_date(year);      
+          fkday fsia(Sunday, date_time::Apr);
+          return fsia.get_date(year);
         }
       }
 
@@ -327,11 +327,11 @@ namespace boost {
       {
         if (year >= year_type(2007)) {
           //first sunday in november
-          fkday fsin(Sunday, gregorian::Nov);
-          return fsin.get_date(year);      
+          fkday fsin(Sunday, date_time::Nov);
+          return fsin.get_date(year);
         } else {
           //last sunday in october
-          lkday lsio(Sunday, gregorian::Oct);
+          lkday lsio(Sunday, date_time::Oct);
           return lsio.get_date(year);
         }
       }
@@ -358,15 +358,15 @@ namespace boost {
       //! Calculates if the given local time is dst or not
       /*! @retval Always is_not_in_dst since this is for zones without dst
        */
-      static time_is_dst_result local_is_dst(const date_type&, 
-                                             const time_duration_type&) 
+      static time_is_dst_result local_is_dst(const date_type&,
+                                             const time_duration_type&)
       {
         return is_not_in_dst;
       }
-    
+
       //! Calculates if the given utc time is in dst
-      static time_is_dst_result utc_is_dst(const date_type&, 
-                                           const time_duration_type&) 
+      static time_is_dst_result utc_is_dst(const date_type&,
+                                           const time_duration_type&)
       {
         return is_not_in_dst;
       }
@@ -376,7 +376,7 @@ namespace boost {
         return false;
       }
 
-      static time_duration_type dst_offset() 
+      static time_duration_type dst_offset()
       {
         return time_duration_type(0,0,0);
       }

--- a/include/boost/date_time/dst_transition_generators.hpp
+++ b/include/boost/date_time/dst_transition_generators.hpp
@@ -7,7 +7,7 @@
 #ifndef DATE_TIME_DATE_DST_TRANSITION_DAY_GEN_HPP__
 #define DATE_TIME_DATE_DST_TRANSITION_DAY_GEN_HPP__
 
-
+#include <string>
 
 namespace boost {
 namespace date_time {

--- a/include/boost/date_time/find_match.hpp
+++ b/include/boost/date_time/find_match.hpp
@@ -9,7 +9,7 @@
  * $Date$
  */
 
-
+#include <string>
 
 namespace boost {
 namespace date_time {

--- a/include/boost/date_time/format_date_parser.hpp
+++ b/include/boost/date_time/format_date_parser.hpp
@@ -3,7 +3,7 @@
 #define DATE_TIME_FORMAT_DATE_PARSER_HPP__
 
 /* Copyright (c) 2004-2005 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
@@ -32,11 +32,11 @@ namespace std {
 }
 #endif
 namespace boost { namespace date_time {
-  
+
 //! Helper function for parsing fixed length strings into integers
-/*! Will consume 'length' number of characters from stream. Consumed 
- * character are transfered to parse_match_result struct. 
- * Returns '-1' if no number can be parsed or incorrect number of 
+/*! Will consume 'length' number of characters from stream. Consumed
+ * character are transfered to parse_match_result struct.
+ * Returns '-1' if no number can be parsed or incorrect number of
  * digits in stream. */
 template<typename int_type, typename charT>
 inline
@@ -50,12 +50,12 @@ fixed_string_to_int(std::istreambuf_iterator<charT>& itr,
   //typedef std::basic_string<charT>  string_type;
   unsigned int j = 0;
   //string_type s;
-  while (j < length && itr != stream_end && 
+  while (j < length && itr != stream_end &&
       (std::isdigit(*itr) || *itr == fill_char)) {
     if(*itr == fill_char) {
-      /* Since a fill_char can be anything, we convert it to a zero. 
+      /* Since a fill_char can be anything, we convert it to a zero.
        * lexical_cast will behave predictably when zero is used as fill. */
-      mr.cache += ('0'); 
+      mr.cache += ('0');
     }
     else {
       mr.cache += (*itr);
@@ -77,9 +77,9 @@ fixed_string_to_int(std::istreambuf_iterator<charT>& itr,
 }
 
 //! Helper function for parsing fixed length strings into integers
-/*! Will consume 'length' number of characters from stream. Consumed 
- * character are transfered to parse_match_result struct. 
- * Returns '-1' if no number can be parsed or incorrect number of 
+/*! Will consume 'length' number of characters from stream. Consumed
+ * character are transfered to parse_match_result struct.
+ * Returns '-1' if no number can be parsed or incorrect number of
  * digits in stream. */
 template<typename int_type, typename charT>
 inline
@@ -93,8 +93,8 @@ fixed_string_to_int(std::istreambuf_iterator<charT>& itr,
 }
 
 //! Helper function for parsing varied length strings into integers
-/*! Will consume 'max_length' characters from stream only if those 
- * characters are digits. Returns '-1' if no number can be parsed. 
+/*! Will consume 'max_length' characters from stream only if those
+ * characters are digits. Returns '-1' if no number can be parsed.
  * Will not parse a number preceeded by a '+' or '-'. */
 template<typename int_type, typename charT>
 inline
@@ -133,7 +133,7 @@ var_string_to_int(std::istreambuf_iterator<charT>& itr,
  -  %W - Week number 00 to 53 where Monday is first day of week 1
  -  %x - facet default date representation
  -  %y - Year without the century - eg: 04 for 2004
- -  %Y - Year with century 
+ -  %Y - Year with century
 
  The weekday specifiers (%a and %A) do not add to the date construction,
  but they provide a way to skip over the weekday names for formats that
@@ -142,7 +142,7 @@ var_string_to_int(std::istreambuf_iterator<charT>& itr,
  todo -- Another interesting feature that this approach could provide is
          an option to fill in any missing fields with the current values
          from the clock.  So if you have %m-%d the parser would detect
-         the missing year value and fill it in using the clock. 
+         the missing year value and fill it in using the clock.
 
  todo -- What to do with the %x.  %x in the classic facet is just bad...
 
@@ -166,7 +166,7 @@ class format_date_parser
   typedef std::vector<std::basic_string<charT> > input_collection_type;
 
   // TODO sv_parser uses its default constructor - write the others
-  
+
   format_date_parser(const string_type& format_str,
                      const input_collection_type& month_short_names,
                      const input_collection_type& month_long_names,
@@ -178,7 +178,7 @@ class format_date_parser
     m_weekday_short_names(weekday_short_names),
     m_weekday_long_names(weekday_long_names)
   {}
-  
+
   format_date_parser(const string_type& format_str,
                      const std::locale& locale) :
     m_format(format_str),
@@ -196,7 +196,7 @@ class format_date_parser
     this->m_weekday_short_names = fdp.m_weekday_short_names;
     this->m_weekday_long_names = fdp.m_weekday_long_names;
   }
-  
+
   string_type format() const
   {
     return m_format;
@@ -225,7 +225,7 @@ class format_date_parser
   }
 
   date_type
-  parse_date(const string_type& value, 
+  parse_date(const string_type& value,
              const string_type& format_str,
              const special_values_parser<date_type,charT>& sv_parser) const
   {
@@ -236,49 +236,49 @@ class format_date_parser
   }
 
   date_type
-  parse_date(std::istreambuf_iterator<charT>& sitr, 
+  parse_date(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              const special_values_parser<date_type,charT>& sv_parser) const
   {
     return parse_date(sitr, stream_end, m_format, sv_parser);
   }
 
-  /*! Of all the objects that the format_date_parser can parse, only a 
-   * date can be a special value. Therefore, only parse_date checks 
+  /*! Of all the objects that the format_date_parser can parse, only a
+   * date can be a special value. Therefore, only parse_date checks
    * for special_values. */
   date_type
-  parse_date(std::istreambuf_iterator<charT>& sitr, 
+  parse_date(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str,
              const special_values_parser<date_type,charT>& sv_parser) const
   {
     bool use_current_char = false;
-    
-    // skip leading whitespace
-    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
 
-    short year(0), month(0), day(0), day_of_year(0);// wkday(0); 
-    /* Initialized the following to their minimum values. These intermediate 
-     * objects are used so we get specific exceptions when part of the input 
-     * is unparsable. 
+    // skip leading whitespace
+    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
+
+    short year(0), month(0), day(0), day_of_year(0);// wkday(0);
+    /* Initialized the following to their minimum values. These intermediate
+     * objects are used so we get specific exceptions when part of the input
+     * is unparsable.
      * Ex: "205-Jan-15" will throw a bad_year, "2005-Jsn-15"- bad_month, etc.*/
     year_type t_year(1400);
     month_type t_month(1);
     day_type t_day(1);
     day_of_week_type wkday(0);
-    
-    
+
+
     const_itr itr(format_str.begin());
     while (itr != format_str.end() && (sitr != stream_end)) {
       if (*itr == '%') {
         if ( ++itr == format_str.end())
-        	break;
+          break;
         if (*itr != '%') {
           switch(*itr) {
-          case 'a': 
+          case 'a':
             {
               //this value is just throw away.  It could be used for
-              //error checking potentially, but it isn't helpful in 
+              //error checking potentially, but it isn't helpful in
               //actually constructing the date - we just need to get it
               //out of the stream
               match_results mr = m_weekday_short_names.match(sitr, stream_end);
@@ -294,10 +294,10 @@ class format_date_parser
               }
               break;
             }
-          case 'A': 
+          case 'A':
             {
               //this value is just throw away.  It could be used for
-              //error checking potentially, but it isn't helpful in 
+              //error checking potentially, but it isn't helpful in
               //actually constructing the date - we just need to get it
               //out of the stream
               match_results mr = m_weekday_long_names.match(sitr, stream_end);
@@ -313,7 +313,7 @@ class format_date_parser
               }
               break;
             }
-          case 'b': 
+          case 'b':
             {
               match_results mr = m_month_short_names.match(sitr, stream_end);
               if(mr.current_match == match_results::PARSE_ERROR) {
@@ -328,7 +328,7 @@ class format_date_parser
               }
               break;
             }
-          case 'B': 
+          case 'B':
             {
               match_results mr = m_month_long_names.match(sitr, stream_end);
               if(mr.current_match == match_results::PARSE_ERROR) {
@@ -343,7 +343,7 @@ class format_date_parser
               }
               break;
             }
-          case 'd': 
+          case 'd':
             {
               match_results mr;
               day = fixed_string_to_int<short, charT>(sitr, stream_end, mr, 2);
@@ -355,7 +355,7 @@ class format_date_parser
               t_day = day_type(day);
               break;
             }
-          case 'e': 
+          case 'e':
             {
               match_results mr;
               day = fixed_string_to_int<short, charT>(sitr, stream_end, mr, 2, ' ');
@@ -367,7 +367,7 @@ class format_date_parser
               t_day = day_type(day);
               break;
             }
-          case 'j': 
+          case 'j':
             {
               match_results mr;
               day_of_year = fixed_string_to_int<short, charT>(sitr, stream_end, mr, 3);
@@ -381,7 +381,7 @@ class format_date_parser
               t_day_of_year = day_of_year_type(day_of_year);
               break;
             }
-          case 'm': 
+          case 'm':
             {
               match_results mr;
               month = fixed_string_to_int<short, charT>(sitr, stream_end, mr, 2);
@@ -393,7 +393,7 @@ class format_date_parser
               t_month = month_type(month);
               break;
             }
-          case 'Y': 
+          case 'Y':
             {
               match_results mr;
               year = fixed_string_to_int<short, charT>(sitr, stream_end, mr, 4);
@@ -405,7 +405,7 @@ class format_date_parser
               t_year = year_type(year);
               break;
             }
-          case 'y': 
+          case 'y':
             {
               match_results mr;
               year = fixed_string_to_int<short, charT>(sitr, stream_end, mr, 2);
@@ -420,14 +420,14 @@ class format_date_parser
             }
           default:
             {} //ignore those we don't understand
-            
+
           }//switch
-          
+
         }
         else { // itr == '%', second consecutive
           sitr++;
         }
-        
+
         itr++; //advance past format specifier
       }
       else {  //skip past chars in format and in buffer
@@ -440,48 +440,48 @@ class format_date_parser
         }
       }
     }
-    
+
     if (day_of_year > 0) {
       date_type d(static_cast<unsigned short>(year-1),12,31); //end of prior year
       return d + duration_type(day_of_year);
     }
-    
-    return date_type(t_year, t_month, t_day); // exceptions were thrown earlier 
-                                        // if input was no good 
+
+    return date_type(t_year, t_month, t_day); // exceptions were thrown earlier
+                                        // if input was no good
   }
- 
+
   //! Throws bad_month if unable to parse
   month_type
-  parse_month(std::istreambuf_iterator<charT>& sitr, 
+  parse_month(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str) const
   {
     match_results mr;
     return parse_month(sitr, stream_end, format_str, mr);
   }
- 
+
   //! Throws bad_month if unable to parse
   month_type
-  parse_month(std::istreambuf_iterator<charT>& sitr, 
+  parse_month(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str,
              match_results& mr) const
   {
     bool use_current_char = false;
-    
+
     // skip leading whitespace
-    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
+    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
 
     short month(0);
-    
+
     const_itr itr(format_str.begin());
     while (itr != format_str.end() && (sitr != stream_end)) {
       if (*itr == '%') {
         if ( ++itr == format_str.end())
-        	break;
+          break;
         if (*itr != '%') {
           switch(*itr) {
-          case 'b': 
+          case 'b':
             {
               mr = m_month_short_names.match(sitr, stream_end);
               month = mr.current_match;
@@ -490,7 +490,7 @@ class format_date_parser
               }
               break;
             }
-          case 'B': 
+          case 'B':
             {
               mr = m_month_long_names.match(sitr, stream_end);
               month = mr.current_match;
@@ -499,23 +499,23 @@ class format_date_parser
               }
               break;
             }
-          case 'm': 
+          case 'm':
             {
               month = var_string_to_int<short, charT>(sitr, stream_end, 2);
-              // var_string_to_int returns -1 if parse failed. That will 
+              // var_string_to_int returns -1 if parse failed. That will
               // cause a bad_month exception to be thrown so we do nothing here
               break;
             }
           default:
             {} //ignore those we don't understand
-            
+
           }//switch
-          
+
         }
         else { // itr == '%', second consecutive
           sitr++;
         }
-        
+
         itr++; //advance past format specifier
       }
       else {  //skip past chars in format and in buffer
@@ -528,27 +528,27 @@ class format_date_parser
         }
       }
     }
-    
+
     return month_type(month); // throws bad_month exception when values are zero
   }
 
   //! Expects 1 or 2 digits 1-31. Throws bad_day_of_month if unable to parse
   day_type
-  parse_var_day_of_month(std::istreambuf_iterator<charT>& sitr, 
+  parse_var_day_of_month(std::istreambuf_iterator<charT>& sitr,
                          std::istreambuf_iterator<charT>& stream_end) const
   {
     // skip leading whitespace
-    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
+    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
 
     return day_type(var_string_to_int<short, charT>(sitr, stream_end, 2));
   }
   //! Expects 2 digits 01-31. Throws bad_day_of_month if unable to parse
   day_type
-  parse_day_of_month(std::istreambuf_iterator<charT>& sitr, 
+  parse_day_of_month(std::istreambuf_iterator<charT>& sitr,
                      std::istreambuf_iterator<charT>& stream_end) const
   {
     // skip leading whitespace
-    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
+    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
 
     //return day_type(var_string_to_int<short, charT>(sitr, stream_end, 2));
     match_results mr;
@@ -556,7 +556,7 @@ class format_date_parser
   }
 
   day_of_week_type
-  parse_weekday(std::istreambuf_iterator<charT>& sitr, 
+  parse_weekday(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str) const
   {
@@ -564,29 +564,29 @@ class format_date_parser
     return parse_weekday(sitr, stream_end, format_str, mr);
   }
   day_of_week_type
-  parse_weekday(std::istreambuf_iterator<charT>& sitr, 
+  parse_weekday(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str,
              match_results& mr) const
   {
     bool use_current_char = false;
-    
+
     // skip leading whitespace
-    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
+    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
 
     short wkday(0);
-    
+
     const_itr itr(format_str.begin());
     while (itr != format_str.end() && (sitr != stream_end)) {
       if (*itr == '%') {
         if ( ++itr == format_str.end())
-        	break;
+          break;
         if (*itr != '%') {
           switch(*itr) {
-          case 'a': 
+          case 'a':
             {
               //this value is just throw away.  It could be used for
-              //error checking potentially, but it isn't helpful in 
+              //error checking potentially, but it isn't helpful in
               //actually constructing the date - we just need to get it
               //out of the stream
               mr = m_weekday_short_names.match(sitr, stream_end);
@@ -596,10 +596,10 @@ class format_date_parser
               }
               break;
             }
-          case 'A': 
+          case 'A':
             {
               //this value is just throw away.  It could be used for
-              //error checking potentially, but it isn't helpful in 
+              //error checking potentially, but it isn't helpful in
               //actually constructing the date - we just need to get it
               //out of the stream
               mr = m_weekday_long_names.match(sitr, stream_end);
@@ -617,14 +617,14 @@ class format_date_parser
             }
           default:
             {} //ignore those we don't understand
-            
+
           }//switch
-          
+
         }
         else { // itr == '%', second consecutive
           sitr++;
         }
-        
+
         itr++; //advance past format specifier
       }
       else {  //skip past chars in format and in buffer
@@ -637,14 +637,14 @@ class format_date_parser
         }
       }
     }
-    
-    return day_of_week_type(wkday); // throws bad_day_of_month exception 
+
+    return day_of_week_type(wkday); // throws bad_day_of_month exception
                                     // when values are zero
   }
-  
+
   //! throws bad_year if unable to parse
   year_type
-  parse_year(std::istreambuf_iterator<charT>& sitr, 
+  parse_year(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str) const
   {
@@ -654,21 +654,21 @@ class format_date_parser
 
   //! throws bad_year if unable to parse
   year_type
-  parse_year(std::istreambuf_iterator<charT>& sitr, 
+  parse_year(std::istreambuf_iterator<charT>& sitr,
              std::istreambuf_iterator<charT>& stream_end,
              string_type format_str,
              match_results& mr) const
   {
     // skip leading whitespace
-    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
+    while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
 
     unsigned short year(0);
-    
+
     const_itr itr(format_str.begin());
     while (itr != format_str.end() && (sitr != stream_end)) {
       if (*itr == '%') {
         if ( ++itr == format_str.end())
-        	break;
+          break;
         if (*itr != '%') {
           //match_results mr;
           switch(*itr) {
@@ -687,14 +687,14 @@ class format_date_parser
             }
           default:
             {} //ignore those we don't understand
-            
+
           }//switch
-          
+
         }
         else { // itr == '%', second consecutive
           sitr++;
         }
-        
+
         itr++; //advance past format specifier
       }
       else {  //skip past chars in format and in buffer
@@ -702,11 +702,11 @@ class format_date_parser
         sitr++;
       }
     }
-    
+
     return year_type(year); // throws bad_year exception when values are zero
   }
-  
-  
+
+
  private:
   string_type m_format;
   parse_tree_type m_month_short_names;

--- a/include/boost/date_time/gregorian/greg_month.hpp
+++ b/include/boost/date_time/gregorian/greg_month.hpp
@@ -11,14 +11,9 @@
 
 #include <boost/date_time/constrained_value.hpp>
 #include <boost/date_time/date_defs.hpp>
-#include "boost/date_time/special_defs.hpp"
 #include <boost/date_time/compiler_config.hpp>
-#include <boost/date_time/find_match.hpp>
 #include <stdexcept>
 #include <string>
-#include <map>
-#include <algorithm>
-#include <cctype>
 
 namespace boost {
 namespace gregorian {
@@ -40,7 +35,7 @@ namespace gregorian {
   using date_time::Dec;
   using date_time::NotAMonth;
   using date_time::NumMonths;
-  
+
   //! Exception thrown if a greg_month is constructed with a value out of range
   struct BOOST_SYMBOL_VISIBLE bad_month : public std::out_of_range
   {
@@ -51,14 +46,14 @@ namespace gregorian {
   //! A constrained range that implements the gregorian_month rules
   typedef CV::constrained_value<greg_month_policies> greg_month_rep;
 
-  
+
   //! Wrapper class to represent months in gregorian based calendar
   class BOOST_DATE_TIME_DECL greg_month : public greg_month_rep {
   public:
     typedef date_time::months_of_year month_enum;
 
     //! Construct a month from the months_of_year enumeration
-    BOOST_CXX14_CONSTEXPR greg_month(month_enum theMonth) : 
+    BOOST_CXX14_CONSTEXPR greg_month(month_enum theMonth) :
       greg_month_rep(static_cast<greg_month_rep::value_type>(theMonth)) {}
     //! Construct from a short value
     BOOST_CXX14_CONSTEXPR greg_month(value_type theMonth) : greg_month_rep(theMonth) {}
@@ -73,7 +68,7 @@ namespace gregorian {
     as_short_string() const
     {
       static const char* const short_month_names[NumMonths]
-	= {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec", "NAM"};
+        = {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec", "NAM"};
       return short_month_names[value_-1];
     }
 
@@ -82,8 +77,8 @@ namespace gregorian {
     as_long_string() const
     {
       static const char* const long_month_names[NumMonths]
-	= {"January","February","March","April","May","June","July","August",
-	   "September","October","November","December","NotAMonth"};
+        = {"January","February","March","April","May","June","July","August",
+           "September","October","November","December","NotAMonth"};
       return long_month_names[value_-1];
     }
 
@@ -94,8 +89,8 @@ namespace gregorian {
     as_short_wstring() const
     {
       static const wchar_t* const w_short_month_names[NumMonths]
-	= {L"Jan",L"Feb",L"Mar",L"Apr",L"May",L"Jun",L"Jul",L"Aug",L"Sep",L"Oct",
-	   L"Nov",L"Dec",L"NAM"};
+        = {L"Jan",L"Feb",L"Mar",L"Apr",L"May",L"Jun",L"Jul",L"Aug",L"Sep",L"Oct",
+           L"Nov",L"Dec",L"NAM"};
       return w_short_month_names[value_-1];
     }
 
@@ -104,8 +99,8 @@ namespace gregorian {
     as_long_wstring() const
     {
       static const wchar_t* const w_long_month_names[NumMonths]
-	= {L"January",L"February",L"March",L"April",L"May",L"June",L"July",L"August",
-	   L"September",L"October",L"November",L"December",L"NotAMonth"};
+        = {L"January",L"February",L"March",L"April",L"May",L"June",L"July",L"August",
+           L"September",L"October",L"November",L"December",L"NotAMonth"};
       return w_long_month_names[value_-1];
     }
 
@@ -133,33 +128,6 @@ namespace gregorian {
 #endif // BOOST_NO_STD_WSTRING
   };
 
-  //! Return special_value from string argument
-  /*! Return special_value from string argument. If argument is
-   * not one of the special value names (defined in names.hpp),
-   * return 'not_special' */
-  inline
-  date_time::special_values
-  special_value_from_string(const std::string& s) {
-    using namespace date_time;
-    static const char* const special_value_names[date_time::NumSpecialValues]
-      = {"not-a-date-time","-infinity","+infinity","min_date_time",
-	 "max_date_time","not_special"};
-
-    short i = date_time::find_match(special_value_names,
-                                    special_value_names,
-                                    date_time::NumSpecialValues,
-                                    s);
-    if(i >= date_time::NumSpecialValues) { // match not found
-      return not_special;
-    }
-    else {
-      return static_cast<special_values>(i);
-    }
-  }
-
-
 } } //namespace gregorian
-
-
 
 #endif

--- a/include/boost/date_time/gregorian/greg_weekday.hpp
+++ b/include/boost/date_time/gregorian/greg_weekday.hpp
@@ -51,8 +51,8 @@ namespace gregorian {
     //! Return a 3 digit english string of the day of week (eg: Sun)
     const char* as_short_string() const
     {
-      static const char* const short_weekday_names[]=
-	{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+      static const char* const short_weekday_names[]
+        = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
       return short_weekday_names[value_];
     }
@@ -61,7 +61,7 @@ namespace gregorian {
     const char* as_long_string() const
     {
       static const char* const long_weekday_names[]
-	= {"Sunday","Monday","Tuesday","Wednesday", "Thursday", "Friday", "Saturday"};
+        = {"Sunday","Monday","Tuesday","Wednesday", "Thursday", "Friday", "Saturday"};
 
       return long_weekday_names[value_];
     }
@@ -73,7 +73,7 @@ namespace gregorian {
     const wchar_t* as_short_wstring() const
     {
       static const wchar_t* const w_short_weekday_names[]={L"Sun", L"Mon", L"Tue",
-							   L"Wed", L"Thu", L"Fri", L"Sat"};
+                                                           L"Wed", L"Thu", L"Fri", L"Sat"};
       return w_short_weekday_names[value_];
     }
 
@@ -81,8 +81,8 @@ namespace gregorian {
     const wchar_t* as_long_wstring()  const
     {
       static const wchar_t* const w_long_weekday_names[]= {L"Sunday",L"Monday",L"Tuesday",
-							   L"Wednesday", L"Thursday",
-							   L"Friday", L"Saturday"};
+                                                           L"Wednesday", L"Thursday",
+                                                           L"Friday", L"Saturday"};
       return w_long_weekday_names[value_];
     }
 

--- a/include/boost/date_time/gregorian/parsers.hpp
+++ b/include/boost/date_time/gregorian/parsers.hpp
@@ -9,44 +9,63 @@
  * $Date$
  */
 
-#include "boost/date_time/gregorian/gregorian_types.hpp"
-#include "boost/date_time/date_parsing.hpp"
-#include "boost/date_time/compiler_config.hpp"
-#include "boost/date_time/parse_format_base.hpp"
+#include <boost/date_time/gregorian/gregorian_types.hpp>
+#include <boost/date_time/date_parsing.hpp>
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/parse_format_base.hpp>
+#include <boost/date_time/special_defs.hpp>
+#include <boost/date_time/find_match.hpp>
 #include <string>
-#include <sstream>
+#include <iterator>
 
 namespace boost {
 namespace gregorian {
 
   //! Return special_value from string argument
-  /*! Return special_value from string argument. If argument is 
-   * not one of the special value names (defined in src/gregorian/names.hpp), 
+  /*! Return special_value from string argument. If argument is
+   * not one of the special value names (defined in names.hpp),
    * return 'not_special' */
-  BOOST_DATE_TIME_DECL special_values special_value_from_string(const std::string& s);
+  inline
+  date_time::special_values
+  special_value_from_string(const std::string& s) {
+    static const char* const special_value_names[date_time::NumSpecialValues]
+      = {"not-a-date-time","-infinity","+infinity","min_date_time",
+         "max_date_time","not_special"};
+
+    short i = date_time::find_match(special_value_names,
+                                    special_value_names,
+                                    date_time::NumSpecialValues,
+                                    s);
+    if(i >= date_time::NumSpecialValues) { // match not found
+      return date_time::not_special;
+    }
+    else {
+      return static_cast<date_time::special_values>(i);
+    }
+  }
 
   //! Deprecated: Use from_simple_string
-  inline date from_string(std::string s) {
+  inline date from_string(const std::string& s) {
     return date_time::parse_date<date>(s);
   }
 
   //! From delimited date string where with order year-month-day eg: 2002-1-25 or 2003-Jan-25 (full month name is also accepted)
-  inline date from_simple_string(std::string s) {
+  inline date from_simple_string(const std::string& s) {
     return date_time::parse_date<date>(s, date_time::ymd_order_iso);
   }
   
   //! From delimited date string where with order year-month-day eg: 1-25-2003 or Jan-25-2003 (full month name is also accepted)
-  inline date from_us_string(std::string s) {
+  inline date from_us_string(const std::string& s) {
     return date_time::parse_date<date>(s, date_time::ymd_order_us);
   }
   
   //! From delimited date string where with order day-month-year eg: 25-1-2002 or 25-Jan-2003 (full month name is also accepted)
-  inline date from_uk_string(std::string s) {
+  inline date from_uk_string(const std::string& s) {
     return date_time::parse_date<date>(s, date_time::ymd_order_dmy);
   }
   
   //! From iso type date string where with order year-month-day eg: 20020125
-  inline date from_undelimited_string(std::string s) {
+  inline date from_undelimited_string(const std::string& s) {
     return date_time::parse_undelimited_date<date>(s);
   }
 

--- a/include/boost/date_time/local_time/local_time_io.hpp
+++ b/include/boost/date_time/local_time/local_time_io.hpp
@@ -8,12 +8,15 @@
  * $Date$
  */
 
+#include <string>
 #include <locale>
 #include <iostream>
 #include <iterator> // i/ostreambuf_iterator
 #include <boost/io/ios_state.hpp>
+#include <boost/date_time/special_defs.hpp>
 #include <boost/date_time/time_facet.hpp>
 #include <boost/date_time/string_convert.hpp>
+#include <boost/date_time/local_time/local_time_types.hpp>
 #include <boost/date_time/local_time/local_date_time.hpp>
 #include <boost/date_time/local_time/posix_time_zone.hpp>
 #include <boost/date_time/local_time/conversion.hpp> // to_tm will be needed in the facets

--- a/include/boost/date_time/period_formatter.hpp
+++ b/include/boost/date_time/period_formatter.hpp
@@ -3,14 +3,17 @@
 #define DATETIME_PERIOD_FORMATTER_HPP___
 
 /* Copyright (c) 2002-2004 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
  * $Date$
  */
 
-
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <iterator>
 
 namespace boost { namespace date_time {
 
@@ -19,14 +22,14 @@ namespace boost { namespace date_time {
   /*! Provides settings for the following:
    *   - period_separator -- default '/'
    *   - period_open_start_delimeter -- default '['
-   *   - period_open_range_end_delimeter -- default ')' 
-   *   - period_closed_range_end_delimeter -- default ']' 
+   *   - period_open_range_end_delimeter -- default ')'
+   *   - period_closed_range_end_delimeter -- default ']'
    *   - display_as_open_range, display_as_closed_range -- default closed_range
    *
    *  Thus the default formatting for a period is as follows:
    *@code
    *  [period.start()/period.last()]
-   *@endcode 
+   *@endcode
    *  So for a typical date_period this would be
    *@code
    *  [2004-Jan-04/2004-Feb-01]
@@ -34,13 +37,13 @@ namespace boost { namespace date_time {
    * where the date formatting is controlled by the date facet
    */
   template <class CharT, class OutItrT = std::ostreambuf_iterator<CharT, std::char_traits<CharT> > >
-  class period_formatter { 
+  class period_formatter {
   public:
     typedef std::basic_string<CharT> string_type;
     typedef CharT                    char_type;
     typedef typename std::basic_string<char_type>::const_iterator const_itr_type;
     typedef std::vector<std::basic_string<CharT> > collection_type;
-    
+
     static const char_type default_period_separator[2];
     static const char_type default_period_start_delimeter[2];
     static const char_type default_period_open_range_end_delimeter[2];
@@ -49,8 +52,8 @@ namespace boost { namespace date_time {
     enum range_display_options { AS_OPEN_RANGE, AS_CLOSED_RANGE };
 
     //! Constructor that sets up period formatter options -- default should suffice most cases.
-    period_formatter(range_display_options range_option_in = AS_CLOSED_RANGE, 
-                     const char_type* const period_separator = default_period_separator, 
+    period_formatter(range_display_options range_option_in = AS_CLOSED_RANGE,
+                     const char_type* const period_separator = default_period_separator,
                      const char_type* const period_start_delimeter = default_period_start_delimeter,
                      const char_type* const period_open_range_end_delimeter = default_period_open_range_end_delimeter,
                      const char_type* const period_closed_range_end_delimeter = default_period_closed_range_end_delimeter) :
@@ -62,7 +65,7 @@ namespace boost { namespace date_time {
     {}
 
     //! Puts the characters between period elements into stream -- default is /
-    OutItrT put_period_separator(OutItrT& oitr) const 
+    OutItrT put_period_separator(OutItrT& oitr) const
     {
       const_itr_type ci = m_period_separator.begin();
       while (ci != m_period_separator.end()) {
@@ -73,7 +76,7 @@ namespace boost { namespace date_time {
     }
 
     //! Puts the period start characters into stream -- default is [
-    OutItrT put_period_start_delimeter(OutItrT& oitr) const 
+    OutItrT put_period_start_delimeter(OutItrT& oitr) const
     {
       const_itr_type ci = m_period_start_delimeter.begin();
       while (ci != m_period_start_delimeter.end()) {
@@ -84,9 +87,9 @@ namespace boost { namespace date_time {
     }
 
     //! Puts the period end characters into stream as controled by open/closed range setting.
-    OutItrT put_period_end_delimeter(OutItrT& oitr) const 
+    OutItrT put_period_end_delimeter(OutItrT& oitr) const
     {
-      
+
       const_itr_type ci, end;
       if (m_range_option == AS_OPEN_RANGE) {
         ci = m_open_range_end_delimeter.begin();
@@ -102,14 +105,14 @@ namespace boost { namespace date_time {
       }
       return oitr;
     }
-   
+
     range_display_options range_option() const
     {
       return m_range_option;
     }
 
     //! Reset the range_option control
-    void 
+    void
     range_option(range_display_options option) const
     {
       m_range_option = option;
@@ -130,13 +133,13 @@ namespace boost { namespace date_time {
     //! Generic code to output a period -- no matter the period type.
     /*! This generic code will output any period using a facet to
      *  to output the 'elements'.  For example, in the case of a date_period
-     *  the elements will be instances of a date which will be formatted 
+     *  the elements will be instances of a date which will be formatted
      *  according the to setup in the passed facet parameter.
-     * 
+     *
      *  The steps for formatting a period are always the same:
      *  - put the start delimiter
      *  - put start element
-     *  - put the separator 
+     *  - put the separator
      *  - put either last or end element depending on range settings
      *  - put end delimeter depending on range settings
      *
@@ -149,9 +152,9 @@ namespace boost { namespace date_time {
      *@endcode
      */
     template<class period_type, class facet_type>
-    OutItrT put_period(OutItrT next, 
-                       std::ios_base& a_ios, 
-                       char_type a_fill, 
+    OutItrT put_period(OutItrT next,
+                       std::ios_base& a_ios,
+                       char_type a_fill,
                        const period_type& p,
                        const facet_type& facet) const {
       put_period_start_delimeter(next);
@@ -167,29 +170,29 @@ namespace boost { namespace date_time {
       return next;
     }
 
-      
+
   private:
-    range_display_options m_range_option;    
+    range_display_options m_range_option;
     string_type m_period_separator;
     string_type m_period_start_delimeter;
     string_type m_open_range_end_delimeter;
     string_type m_closed_range_end_delimeter;
   };
 
-  template <class CharT, class OutItrT>  
-  const typename period_formatter<CharT, OutItrT>::char_type 
+  template <class CharT, class OutItrT>
+  const typename period_formatter<CharT, OutItrT>::char_type
   period_formatter<CharT, OutItrT>::default_period_separator[2] = {'/'};
 
-  template <class CharT, class OutItrT>  
-  const typename period_formatter<CharT, OutItrT>::char_type 
+  template <class CharT, class OutItrT>
+  const typename period_formatter<CharT, OutItrT>::char_type
   period_formatter<CharT, OutItrT>::default_period_start_delimeter[2] = {'['};
 
-  template <class CharT, class OutItrT>  
-  const typename period_formatter<CharT, OutItrT>::char_type 
+  template <class CharT, class OutItrT>
+  const typename period_formatter<CharT, OutItrT>::char_type
   period_formatter<CharT, OutItrT>::default_period_open_range_end_delimeter[2] = {')'};
 
-  template <class CharT, class OutItrT>  
-  const typename period_formatter<CharT, OutItrT>::char_type 
+  template <class CharT, class OutItrT>
+  const typename period_formatter<CharT, OutItrT>::char_type
   period_formatter<CharT, OutItrT>::default_period_closed_range_end_delimeter[2] = {']'};
 
  } } //namespace boost::date_time

--- a/include/boost/date_time/period_parser.hpp
+++ b/include/boost/date_time/period_parser.hpp
@@ -3,14 +3,19 @@
 #define DATETIME_PERIOD_PARSER_HPP___
 
 /* Copyright (c) 2002-2004 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
  * $Date$
  */
 
+#include <ios>
+#include <string>
+#include <vector>
+#include <iterator>
 #include <boost/throw_exception.hpp>
+#include <boost/date_time/special_defs.hpp>
 #include <boost/date_time/string_parse_tree.hpp>
 #include <boost/date_time/string_convert.hpp>
 
@@ -18,12 +23,12 @@
 namespace boost { namespace date_time {
 
 
-  //! Not a facet, but a class used to specify and control period parsing 
+  //! Not a facet, but a class used to specify and control period parsing
   /*! Provides settings for the following:
    *   - period_separator -- default '/'
    *   - period_open_start_delimeter -- default '['
-   *   - period_open_range_end_delimeter -- default ')' 
-   *   - period_closed_range_end_delimeter -- default ']' 
+   *   - period_open_range_end_delimeter -- default ')'
+   *   - period_closed_range_end_delimeter -- default ']'
    *   - display_as_open_range, display_as_closed_range -- default closed_range
    *
    *  For a typical date_period, the contents of the input stream would be
@@ -99,11 +104,11 @@ namespace boost { namespace date_time {
      *  to get the 'elements'.  For example, in the case of a date_period
      *  the elements will be instances of a date which will be parsed
      *  according the to setup in the passed facet parameter.
-     * 
+     *
      *  The steps for parsing a period are always the same:
      *  - consume the start delimiter
      *  - get start element
-     *  - consume the separator 
+     *  - consume the separator
      *  - get either last or end element depending on range settings
      *  - consume the end delimeter depending on range settings
      *
@@ -117,15 +122,15 @@ namespace boost { namespace date_time {
      *@endcode
      */
     template<class period_type, class duration_type, class facet_type>
-    period_type get_period(stream_itr_type& sitr, 
+    period_type get_period(stream_itr_type& sitr,
                            stream_itr_type& stream_end,
-                           std::ios_base& a_ios, 
+                           std::ios_base& a_ios,
                            const period_type& /* p */,
                            const duration_type& dur_unit,
-                           const facet_type& facet) const 
+                           const facet_type& facet) const
     {
       // skip leading whitespace
-      while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; } 
+      while(std::isspace(*sitr) && sitr != stream_end) { ++sitr; }
 
       typedef typename period_type::point_type point_type;
       point_type p1(not_a_date_time), p2(not_a_date_time);
@@ -150,7 +155,7 @@ namespace boost { namespace date_time {
     }
 
   private:
-    collection_type delimiters; 
+    collection_type delimiters;
     period_range_option m_range_option;
 
     enum delim_ids { SEPARATOR, START, OPEN_END, CLOSED_END };
@@ -160,10 +165,10 @@ namespace boost { namespace date_time {
                        stream_itr_type& stream_end,
                        const string_type& delim) const
     {
-      /* string_parse_tree will not parse a string of punctuation characters 
+      /* string_parse_tree will not parse a string of punctuation characters
        * without knowing exactly how many characters to process
-       * Ex [2000. Will not parse out the '[' string without knowing 
-       * to process only one character. By using length of the delimiter 
+       * Ex [2000. Will not parse out the '[' string without knowing
+       * to process only one character. By using length of the delimiter
        * string we can safely iterate past it. */
       string_type s;
       for(unsigned int i = 0; i < delim.length() && sitr != stream_end; ++i) {
@@ -177,20 +182,20 @@ namespace boost { namespace date_time {
     }
   };
 
-  template <class date_type, class char_type>  
-  const typename period_parser<date_type, char_type>::char_type 
+  template <class date_type, class char_type>
+  const typename period_parser<date_type, char_type>::char_type
   period_parser<date_type, char_type>::default_period_separator[2] = {'/'};
 
-  template <class date_type, class char_type>  
-  const typename period_parser<date_type, char_type>::char_type 
+  template <class date_type, class char_type>
+  const typename period_parser<date_type, char_type>::char_type
   period_parser<date_type, char_type>::default_period_start_delimeter[2] = {'['};
 
-  template <class date_type, class char_type>  
-  const typename period_parser<date_type, char_type>::char_type 
+  template <class date_type, class char_type>
+  const typename period_parser<date_type, char_type>::char_type
   period_parser<date_type, char_type>::default_period_open_range_end_delimeter[2] = {')'};
 
-  template <class date_type, class char_type>  
-  const typename period_parser<date_type, char_type>::char_type 
+  template <class date_type, class char_type>
+  const typename period_parser<date_type, char_type>::char_type
   period_parser<date_type, char_type>::default_period_closed_range_end_delimeter[2] = {']'};
 
  } } //namespace boost::date_time

--- a/include/boost/date_time/posix_time/posix_time_config.hpp
+++ b/include/boost/date_time/posix_time/posix_time_config.hpp
@@ -54,9 +54,9 @@ namespace posix_time {
     typedef time_res_traits::tick_type tick_type;
     typedef time_res_traits::impl_type impl_type;
     BOOST_CXX14_CONSTEXPR time_duration(hour_type hour,
-					min_type min,
-					sec_type sec,
-					fractional_seconds_type fs=0) :
+                                        min_type min,
+                                        sec_type sec,
+                                        fractional_seconds_type fs=0) :
       date_time::time_duration<time_duration, time_res_traits>(hour,min,sec,fs)
     {}
    BOOST_CXX14_CONSTEXPR time_duration() :

--- a/include/boost/date_time/posix_time/ptime.hpp
+++ b/include/boost/date_time/posix_time/ptime.hpp
@@ -61,7 +61,7 @@ namespace posix_time {
     BOOST_CXX14_CONSTEXPR 
     ptime() :
       date_time::base_time<time_type,time_system_type>(gregorian::date(not_a_date_time),
-						       time_duration_type(not_a_date_time))
+                                                       time_duration_type(not_a_date_time))
     {}
 #endif // DATE_TIME_NO_DEFAULT_CONSTRUCTOR
 

--- a/include/boost/date_time/string_parse_tree.hpp
+++ b/include/boost/date_time/string_parse_tree.hpp
@@ -10,11 +10,13 @@
  */
 
 
-#include "boost/lexical_cast.hpp" //error without?
-#include "boost/algorithm/string/case_conv.hpp"
+#include <boost/algorithm/string/case_conv.hpp>
+#include <cctype>
 #include <map>
 #include <string>
 #include <vector>
+#include <ostream>
+#include <iterator>
 #include <algorithm>
 
 namespace boost { namespace date_time {

--- a/include/boost/date_time/strings_from_facet.hpp
+++ b/include/boost/date_time/strings_from_facet.hpp
@@ -9,10 +9,12 @@
  * $Date$
  */
 
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <vector>
 #include <locale>
+#include <iterator>
 
 namespace boost { namespace date_time {
 
@@ -50,7 +52,7 @@ gather_month_strings(const std::locale& locale, bool short_strings=true)
     //output each month
     const charT* p_outfmt = outfmt.c_str(), *p_outfmt_end = p_outfmt + outfmt.size();
     tm tm_value;
-    memset(&tm_value, 0, sizeof(tm_value));
+    std::memset(&tm_value, 0, sizeof(tm_value));
     for (int m=0; m < 12; m++) {
       tm_value.tm_mon = m;
       stringstream_type ss;
@@ -103,7 +105,7 @@ gather_weekday_strings(const std::locale& locale, bool short_strings=true)
     //output each month / weekday
     const charT* p_outfmt = outfmt.c_str(), *p_outfmt_end = p_outfmt + outfmt.size();
     tm tm_value;
-    memset(&tm_value, 0, sizeof(tm_value));
+    std::memset(&tm_value, 0, sizeof(tm_value));
     for (int i=0; i < 7; i++) {
       tm_value.tm_wday = i;
       stringstream_type ss;

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -299,8 +299,8 @@ namespace date_time {
     // The argument (ss) must be an integral type
     template <typename T>
     BOOST_CXX14_CONSTEXPR explicit subsecond_duration(T const& ss,
-						      typename boost::enable_if<boost::is_integral<T>,
-						      void>::type* = BOOST_DATE_TIME_NULLPTR) :
+                                                      typename boost::enable_if<boost::is_integral<T>,
+                                                        void>::type* = BOOST_DATE_TIME_NULLPTR) :
       base_duration(impl_type(traits_type::ticks_per_second >= frac_of_second ? ss * adjustment_ratio : ss / adjustment_ratio))
     {
     }

--- a/include/boost/date_time/time_resolution_traits.hpp
+++ b/include/boost/date_time/time_resolution_traits.hpp
@@ -133,9 +133,9 @@ namespace date_time {
     }
     //! Any negative argument results in a negative tick_count
     static BOOST_CXX14_CONSTEXPR tick_type to_tick_count(hour_type hours,
-							 min_type  minutes,
-							 sec_type  seconds,
-							 fractional_seconds_type  fs)
+                                                         min_type  minutes,
+                                                         sec_type  seconds,
+                                                         fractional_seconds_type  fs)
     {
       if(hours < 0 || minutes < 0 || seconds < 0 || fs < 0)
       {

--- a/include/boost/date_time/time_system_counted.hpp
+++ b/include/boost/date_time/time_system_counted.hpp
@@ -2,7 +2,7 @@
 #define DATE_TIME_TIME_SYSTEM_COUNTED_HPP
 
 /* Copyright (c) 2002,2003 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
@@ -10,8 +10,9 @@
  */
 
 
-
-#include "boost/date_time/time_defs.hpp"
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/time_defs.hpp>
+#include <boost/date_time/special_defs.hpp>
 #include <string>
 
 
@@ -30,16 +31,16 @@ namespace date_time {
     typedef typename date_type::ymd_type ymd_type;
     typedef typename config::time_duration_type time_duration_type;
     typedef typename config::resolution_traits   resolution_traits;
-    
+
     BOOST_CXX14_CONSTEXPR
-    counted_time_rep(const date_type& d, const time_duration_type& time_of_day) 
+    counted_time_rep(const date_type& d, const time_duration_type& time_of_day)
       : time_count_(1)
     {
       if(d.is_infinity() || d.is_not_a_date() || time_of_day.is_special()) {
         time_count_ = time_of_day.get_rep() + d.day_count();
         //std::cout << time_count_ << std::endl;
       }
-      else {    
+      else {
         time_count_ = (d.day_number() * frac_sec_per_day()) + time_of_day.ticks();
       }
     }
@@ -68,17 +69,17 @@ namespace date_time {
     BOOST_CXX14_CONSTEXPR
     unsigned long day_count() const
     {
-      /* resolution_traits::as_number returns a boost::int64_t & 
-       * frac_sec_per_day is also a boost::int64_t so, naturally, 
-       * the division operation returns a boost::int64_t. 
-       * The static_cast to an unsigned long is ok (results in no data loss) 
-       * because frac_sec_per_day is either the number of 
-       * microseconds per day, or the number of nanoseconds per day. 
-       * Worst case scenario: resolution_traits::as_number returns the 
-       * maximum value an int64_t can hold and frac_sec_per_day 
-       * is microseconds per day (lowest possible value). 
-       * The division operation will then return a value of 106751991 - 
-       * easily fitting in an unsigned long. 
+      /* resolution_traits::as_number returns a boost::int64_t &
+       * frac_sec_per_day is also a boost::int64_t so, naturally,
+       * the division operation returns a boost::int64_t.
+       * The static_cast to an unsigned long is ok (results in no data loss)
+       * because frac_sec_per_day is either the number of
+       * microseconds per day, or the number of nanoseconds per day.
+       * Worst case scenario: resolution_traits::as_number returns the
+       * maximum value an int64_t can hold and frac_sec_per_day
+       * is microseconds per day (lowest possible value).
+       * The division operation will then return a value of 106751991 -
+       * easily fitting in an unsigned long.
        */
       return static_cast<unsigned long>(resolution_traits::as_number(time_count_) / frac_sec_per_day());
     }
@@ -137,8 +138,8 @@ namespace date_time {
 
     static BOOST_CXX14_CONSTEXPR
     time_rep_type get_time_rep(const date_type& day,
-			       const time_duration_type& tod,
-			       date_time::dst_flags dst=not_dst)
+                               const time_duration_type& tod,
+                               date_time::dst_flags dst=not_dst)
     {
       unused_var(dst);
       return time_rep_type(day, tod);
@@ -151,10 +152,10 @@ namespace date_time {
         return time_rep_type(date_type(not_a_date_time),
                              time_duration_type(not_a_date_time));
       case pos_infin:
-        return time_rep_type(date_type(pos_infin), 
+        return time_rep_type(date_type(pos_infin),
                              time_duration_type(pos_infin));
       case neg_infin:
-        return time_rep_type(date_type(neg_infin), 
+        return time_rep_type(date_type(neg_infin),
                              time_duration_type(neg_infin));
       case max_date_time: {
         time_duration_type td = time_duration_type(24,0,0,0) - time_duration_type(0,0,0,1);
@@ -166,7 +167,7 @@ namespace date_time {
       default:
         return time_rep_type(date_type(not_a_date_time),
                              time_duration_type(not_a_date_time));
-        
+
       }
 
     }
@@ -183,7 +184,7 @@ namespace date_time {
         return time_duration_type(val.get_rep().as_special());
       }
       else{
-        return time_duration_type(0,0,0,val.tod()); 
+        return time_duration_type(0,0,0,val.tod());
       }
     }
     static std::string zone_name(const time_rep_type&)
@@ -201,7 +202,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type add_days(const time_rep_type& base,
-			   const date_duration_type& dd)
+                           const date_duration_type& dd)
     {
       if(base.is_special() || dd.is_special()) {
         return(time_rep_type(base.get_rep() + dd.get_rep()));
@@ -212,7 +213,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type subtract_days(const time_rep_type& base,
-				const date_duration_type& dd)
+                                const date_duration_type& dd)
     {
       if(base.is_special() || dd.is_special()) {
         return(time_rep_type(base.get_rep() - dd.get_rep()));
@@ -223,7 +224,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type subtract_time_duration(const time_rep_type& base,
-					 const time_duration_type& td)
+                                         const time_duration_type& td)
     {
       if(base.is_special() || td.is_special()) {
         return(time_rep_type(base.get_rep() - td.get_rep()));
@@ -234,7 +235,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type add_time_duration(const time_rep_type& base,
-				    time_duration_type td)
+                                    time_duration_type td)
     {
       if(base.is_special() || td.is_special()) {
         return(time_rep_type(base.get_rep() + td.get_rep()));
@@ -245,7 +246,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_duration_type subtract_times(const time_rep_type& lhs,
-				      const time_rep_type& rhs)
+                                      const time_rep_type& rhs)
     {
       if(lhs.is_special() || rhs.is_special()) {
         return(time_duration_type(
@@ -253,10 +254,10 @@ namespace date_time {
       }
       else {
         fractional_seconds_type fs = lhs.time_count() - rhs.time_count();
-        return time_duration_type(0,0,0,fs); 
+        return time_duration_type(0,0,0,fs);
       }
     }
-    
+
   };
 
 

--- a/include/boost/date_time/time_system_split.hpp
+++ b/include/boost/date_time/time_system_split.hpp
@@ -2,7 +2,7 @@
 #define DATE_TIME_TIME_SYSTEM_SPLIT_HPP
 
 /* Copyright (c) 2002,2003,2005 CrystalClear Software, Inc.
- * Use, modification and distribution is subject to the 
+ * Use, modification and distribution is subject to the
  * Boost Software License, Version 1.0. (See accompanying
  * file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
  * Author: Jeff Garland, Bart Garst
@@ -11,15 +11,17 @@
 
 
 #include <string>
-#include <boost/config.hpp>
-#include "boost/date_time/compiler_config.hpp"
-#include "boost/date_time/special_defs.hpp"
+#include <boost/cstdint.hpp>
+#include <boost/date_time/compiler_config.hpp>
+#include <boost/date_time/time_defs.hpp>
+#include <boost/date_time/special_defs.hpp>
+#include <boost/date_time/wrapping_int.hpp>
 
 namespace boost {
 namespace date_time {
 
   //! An unadjusted time system implementation.
-#if (defined(BOOST_DATE_TIME_NO_MEMBER_INIT))  
+#if (defined(BOOST_DATE_TIME_NO_MEMBER_INIT))
   template<typename config, boost::int32_t ticks_per_second>
 #else
   template<typename config>
@@ -35,7 +37,7 @@ namespace date_time {
     typedef typename config::resolution_traits   resolution_traits;
 
     //86400 is number of seconds in a day...
-#if (defined(BOOST_DATE_TIME_NO_MEMBER_INIT))  
+#if (defined(BOOST_DATE_TIME_NO_MEMBER_INIT))
     typedef date_time::wrapping_int<int_type, INT64_C(86400) * ticks_per_second > wrap_int_type;
 #else
    private:
@@ -57,10 +59,10 @@ namespace date_time {
         return time_rep_type(date_type(not_a_date_time),
                              time_duration_type(not_a_date_time));
       case pos_infin:
-        return time_rep_type(date_type(pos_infin), 
+        return time_rep_type(date_type(pos_infin),
                              time_duration_type(pos_infin));
       case neg_infin:
-        return time_rep_type(date_type(neg_infin), 
+        return time_rep_type(date_type(neg_infin),
                              time_duration_type(neg_infin));
       case max_date_time: {
         time_duration_type td = time_duration_type(24,0,0,0) - time_duration_type(0,0,0,1);
@@ -72,7 +74,7 @@ namespace date_time {
       default:
         return time_rep_type(date_type(not_a_date_time),
                              time_duration_type(not_a_date_time));
-        
+
       }
 
     }
@@ -80,8 +82,8 @@ namespace date_time {
     static
     BOOST_CXX14_CONSTEXPR
     time_rep_type get_time_rep(const date_type& day,
-			       const time_duration_type& tod,
-			       date_time::dst_flags /* dst */ = not_dst)
+                               const time_duration_type& tod,
+                               date_time::dst_flags /* dst */ = not_dst)
     {
       if(day.is_special() || tod.is_special()) {
         if(day.is_not_a_date() || tod.is_not_a_date_time()) {
@@ -153,19 +155,19 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type add_days(const time_rep_type& base,
-			   const date_duration_type& dd)
+                           const date_duration_type& dd)
     {
       return time_rep_type(base.day+dd, base.time_of_day);
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type subtract_days(const time_rep_type& base,
-				const date_duration_type& dd)
+                                const date_duration_type& dd)
     {
       return split_timedate_system::get_time_rep(base.day-dd, base.time_of_day);
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type subtract_time_duration(const time_rep_type& base,
-					 const time_duration_type& td)
+                                         const time_duration_type& td)
     {
       if(base.day.is_special() || td.is_special())
       {
@@ -184,7 +186,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_rep_type add_time_duration(const time_rep_type& base,
-				    time_duration_type td)
+                                    time_duration_type td)
     {
       if(base.day.is_special() || td.is_special()) {
         return split_timedate_system::get_time_rep(base.day, td);
@@ -194,7 +196,7 @@ namespace date_time {
         return subtract_time_duration(base,td1);
       }
 
-      wrap_int_type day_offset(base.time_of_day.ticks());      
+      wrap_int_type day_offset(base.time_of_day.ticks());
       date_duration_type day_overflow(static_cast< typename date_duration_type::duration_rep_type >(day_offset.add(td.ticks())));
 
       return time_rep_type(base.day+day_overflow,
@@ -202,7 +204,7 @@ namespace date_time {
     }
     static BOOST_CXX14_CONSTEXPR
     time_duration_type subtract_times(const time_rep_type& lhs,
-				      const time_rep_type& rhs)
+                                      const time_rep_type& rhs)
     {
       date_duration_type dd = lhs.day - rhs.day;
       if (BOOST_LIKELY(!dd.is_special())) {
@@ -215,7 +217,7 @@ namespace date_time {
         return td+td2;
       }
     }
-    
+
   };
 
 } } //namespace date_time

--- a/include/boost/date_time/tz_db_base.hpp
+++ b/include/boost/date_time/tz_db_base.hpp
@@ -245,7 +245,6 @@ namespace boost {
       //! parses rule specs for transition day rules
       rule_type* parse_rules(const string_type& sr, const string_type& er) const
       {
-        using namespace gregorian;
         // start and end rule are of the same type, 
         // both are included here for readability
         typedef typename rule_type::start_rule start_rule;

--- a/include/boost/date_time/year_month_day.hpp
+++ b/include/boost/date_time/year_month_day.hpp
@@ -19,9 +19,9 @@ namespace date_time {
   struct BOOST_SYMBOL_VISIBLE year_month_day_base {
     BOOST_CXX14_CONSTEXPR
     year_month_day_base(YearType  year,
-			MonthType month,
-			DayType   day);
-    
+                        MonthType month,
+                        DayType   day);
+
     YearType year;
     MonthType month;
     DayType day;
@@ -29,8 +29,8 @@ namespace date_time {
     typedef MonthType month_type;
     typedef DayType   day_type;
   };
-  
-  
+
+
   //! A basic constructor
   template<typename YearType, typename MonthType, typename DayType>
   inline BOOST_CXX14_CONSTEXPR
@@ -41,7 +41,7 @@ namespace date_time {
     month(m),
     day(d)
   {}
-  
+
 } }//namespace date_time
 
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,4 +1,6 @@
 import os ;
+import path ;
+import regex ;
 import testing ;
 
 local DATE_TIME_DYNAMIC_PROPERTIES = <define>BOOST_ALL_DYN_LINK <runtime-link>shared <define>BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG <define>BOOST_ALL_NO_LIB ;
@@ -138,6 +140,21 @@ run local_time/testclocks.cpp ;
 #    # std::locale-support toolset::require-boost-spirit-support 
 #    ;
 
+# Iterate over all public headers and generate a self-contained header test to check for any missing includes
+# and basic syntax errors.
+if ! [ os.environ BOOST_DATE_TIME_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS ]
+{
+    local headers_path = [ path.make $(BOOST_ROOT)/libs/date_time/include/boost ] ;
+    for file in [ path.glob-tree $(headers_path) : *.hpp ]
+    {
+        local rel_file = [ path.relative-to $(headers_path) $(file) ] ;
+        # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
+        #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
+        local test_name = [ regex.replace ~hdr/$(rel_file) "/" "-" ] ;
+        #ECHO $(rel_file) ;
+        compile self_contained_header.cpp : <define>"BOOST_DATE_TIME_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(test_name) ;
+    }
+}
 
 
 # Copyright (c) 2000-2020

--- a/test/local_time/testlocal_time.cpp
+++ b/test/local_time/testlocal_time.cpp
@@ -288,8 +288,8 @@ main()
         local_date_time ldt(not_a_date_time);
         tm ldt_tm = to_tm(ldt);
         check("Exception not thrown (special_value to_tm)", false);
-	//does nothing useful but stops compiler from complaining about unused ldt_tm
-	std::cout << ldt_tm.tm_sec << std::endl; 
+        //does nothing useful but stops compiler from complaining about unused ldt_tm
+        std::cout << ldt_tm.tm_sec << std::endl; 
       }catch(std::out_of_range&){
         check("Caught expected exception (special_value to_tm)", true);
       }catch(...){

--- a/test/posix_time/testparse_time.cpp
+++ b/test/posix_time/testparse_time.cpp
@@ -108,20 +108,20 @@ main()
     std::string s1("12:11:10.123456");
     time_duration td1= duration_from_string(s1);
     check("parse time duration: " + s1,
-	  td1 == time_duration(12,11,10,123456));
+          td1 == time_duration(12,11,10,123456));
     std::cout << "td1: " << td1 << std::endl;
 
     std::string s2("12:11:10,123456");
     time_duration td2= boost::date_time::parse_delimited_time_duration<time_duration>(s2);
     check("parse time duration: " + s2,
-	  td2 == time_duration(12,11,10,123456));
+          td2 == time_duration(12,11,10,123456));
     std::cout << "td2: " << td2 << std::endl;
 
     //truncate for non-nanosecond case
     std::string s8b("1:22:33.123456321"); // too many digits
     time_duration td8b= boost::date_time::parse_delimited_time_duration<time_duration>(s8b);
     check("parse time duration: " + s8b,
-	  td8b == time_duration(1,22,33,123456)); // excess digits should be dropped
+          td8b == time_duration(1,22,33,123456)); // excess digits should be dropped
   }
 
 

--- a/test/self_contained_header.cpp
+++ b/test/self_contained_header.cpp
@@ -1,0 +1,22 @@
+/*
+ *             Copyright Andrey Semashev 2020.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   self_contained_header.cpp
+ * \author Andrey Semashev
+ * \date   04.04.2020
+ *
+ * \brief  This file contains a test boilerplate for checking that every public header is self-contained and does not have any missing #includes.
+ */
+
+#define BOOST_DATE_TIME_TEST_INCLUDE_HEADER() <boost/BOOST_DATE_TIME_TEST_HEADER>
+
+#include BOOST_DATE_TIME_TEST_INCLUDE_HEADER()
+
+int main(int, char*[])
+{
+    return 0;
+}


### PR DESCRIPTION
This PR does the following:

- Adds a test generator which checks if every public header is self-contained (i.e. compiles if included alone). This detects missing includes and general syntax and C++ errors. These tests are enabled on a few CI jobs.
- Based on these test failures, fixes errors in headers, like missing includes and incorrect namespace qualification.
- Moves `special_value_from_string` definition from `gregorian/greg_month.hpp` to `gregorian/parsers.hpp` and removes the obsolete declaration in `gregorian/parsers.hpp`. This fixes https://github.com/boostorg/date_time/issues/143.
- Changes `from_string` and similar functions in `gregorian/parsers.hpp` to accept `std::string` by const reference instead of by value to avoid unnecessary copying.
- Converts all tabs to spaces (as per our [coding guidelines](https://www.boost.org/development/requirements.html#Tabs)) and trims trailing spaces in a few places. (Sorry, couldn't resist on this part.)
