### PR TITLE
Change greg_month and greg_weekday to be not marked as exported/impor…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,8 +44,8 @@ environment:
     # on Windows it is important to exercise all the possibilities, especially shared vs static, however most
     # libraries that care about this exercise it in their Jamfiles...
     # B2_ADDRESS_MODEL: address-model=64,32
-    # B2_LINK: link=shared,static
     # B2_THREADING: threading=multi,single
+    B2_LINK: link=shared,static
     B2_VARIANT: variant=release
 
   matrix:

--- a/include/boost/date_time/gregorian/greg_month.hpp
+++ b/include/boost/date_time/gregorian/greg_month.hpp
@@ -48,7 +48,7 @@ namespace gregorian {
 
 
   //! Wrapper class to represent months in gregorian based calendar
-  class BOOST_DATE_TIME_DECL greg_month : public greg_month_rep {
+  class BOOST_SYMBOL_VISIBLE greg_month : public greg_month_rep {
   public:
     typedef date_time::months_of_year month_enum;
 

--- a/include/boost/date_time/gregorian/greg_weekday.hpp
+++ b/include/boost/date_time/gregorian/greg_weekday.hpp
@@ -38,7 +38,7 @@ namespace gregorian {
 
 
   //! Represent a day within a week (range 0==Sun to 6==Sat)
-  class BOOST_DATE_TIME_DECL greg_weekday : public greg_weekday_rep {
+  class BOOST_SYMBOL_VISIBLE greg_weekday : public greg_weekday_rep {
   public:
     typedef boost::date_time::weekdays weekday_enum;
     BOOST_CXX14_CONSTEXPR greg_weekday(value_type day_of_week_num) :


### PR DESCRIPTION
…ted (#146)

* Changed greg_month and greg_weekday to be not marked as exported/imported.

Both greg_month and greg_weekday classes are implemented completely in headers,
so they need not be marked with BOOST_DATE_TIME_DECL. For consistency with other
similar classes, they are now marked with BOOST_SYMBOL_VISIBLE.

This should fix linking errors on Windows/MSVC, where all members of greg_month
and greg_weekday classes remain unresolved as they are expected to be
implemented in a shared library.

* Enabled shared and static linking in AppVeyor CI.