### PR TITLE
Break DateTime <-> Serialization circular dependency

### DIFF
--- a/include/boost/date_time/gregorian/greg_serialize.hpp
+++ b/include/boost/date_time/gregorian/greg_serialize.hpp
@@ -11,27 +11,8 @@
 
 #include "boost/date_time/gregorian/gregorian_types.hpp"
 #include "boost/date_time/gregorian/parsers.hpp"
-#include "boost/serialization/split_free.hpp"
-#include "boost/serialization/nvp.hpp"
+#include "boost/core/nvp.hpp"
 
-  
-// macros to split serialize functions into save & load functions
-// An expanded version is below for gregorian::date
-// NOTE: these macros define template functions in the boost::serialization namespace.
-// They must be expanded *outside* of any namespace
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::date_duration)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::date_duration::duration_rep)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::date_period)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::greg_year)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::greg_month)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::greg_day)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::greg_weekday)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::partial_date)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::nth_kday_of_month)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::first_kday_of_month)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::last_kday_of_month)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::first_kday_before)
-BOOST_SERIALIZATION_SPLIT_FREE(::boost::gregorian::first_kday_after)
 
 namespace boost {
 
@@ -41,15 +22,36 @@ namespace boost {
 
 namespace serialization {
 
+// A macro to split serialize functions into save & load functions.
+// It is here to avoid dependency on Boost.Serialization just for the
+// BOOST_SERIALIZATION_SPLIT_FREE macro
+#define BOOST_DATE_TIME_SPLIT_FREE(T)                                         \
+template<class Archive>                                                       \
+inline void serialize(Archive & ar,                                           \
+                      T & t,                                                  \
+                      const unsigned int file_version)                        \
+{                                                                             \
+    split_free(ar, t, file_version);                                          \
+}
+
 /*! Method that does serialization for gregorian::date -- splits to load/save
  */
-template<class Archive>                         
-inline void serialize(Archive & ar,                               
-                      ::boost::gregorian::date & d,
-                      const unsigned int file_version)
-{
-  split_free(ar, d, file_version);              
-}                                               
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::date)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::date_duration)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::date_duration::duration_rep)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::date_period)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::greg_year)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::greg_month)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::greg_day)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::greg_weekday)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::partial_date)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::nth_kday_of_month)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::first_kday_of_month)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::last_kday_of_month)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::first_kday_before)
+BOOST_DATE_TIME_SPLIT_FREE(::boost::gregorian::first_kday_after)
+
+#undef BOOST_DATE_TIME_SPLIT_FREE
 
 //! Function to save gregorian::date objects using serialization lib
 /*! Dates are serialized into a string for transport and storage. 


### PR DESCRIPTION
Breaks DateTime -> Serialization -> Spirit -> Thread -> DateTime chain.

The Serialization documentation seems to be explicitly allow this:
https://www.boost.org/doc/libs/1_72_0/libs/serialization/doc/traits.html#version
https://www.boost.org/doc/libs/1_73_0/libs/serialization/doc/serialization.html#splitting