### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/date_time/date_facet.hpp
+++ b/include/boost/date_time/date_facet.hpp
@@ -9,10 +9,10 @@
  * $Date$
  */
 
+#include <iterator> // ostreambuf_iterator
 #include <locale>
 #include <string>
 #include <vector>
-#include <iterator> // ostreambuf_iterator
 #include <boost/throw_exception.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/date_time/compiler_config.hpp>
@@ -316,23 +316,23 @@ namespace boost { namespace date_time {
                               string_type a_format) const
     {
       // update format string with custom names
-      if (m_weekday_long_names.size()) {
+      if (!m_weekday_long_names.empty()) {
         boost::algorithm::replace_all(a_format,
                                       long_weekday_format,
                                       m_weekday_long_names[tm_value.tm_wday]);
       }
-      if (m_weekday_short_names.size()) {
+      if (!m_weekday_short_names.empty()) {
         boost::algorithm::replace_all(a_format,
                                       short_weekday_format,
                                       m_weekday_short_names[tm_value.tm_wday]);
 
       }
-      if (m_month_long_names.size()) {
+      if (!m_month_long_names.empty()) {
         boost::algorithm::replace_all(a_format,
                                       long_month_format,
                                       m_month_long_names[tm_value.tm_mon]);
       }
-      if (m_month_short_names.size()) {
+      if (!m_month_short_names.empty()) {
         boost::algorithm::replace_all(a_format,
                                       short_month_format,
                                       m_month_short_names[tm_value.tm_mon]);
@@ -762,6 +762,5 @@ namespace boost { namespace date_time {
     {'%','Y','-','%','b','-','%','d'};
 
 } } // namespaces
-
 
 #endif

--- a/include/boost/date_time/date_generators.hpp
+++ b/include/boost/date_time/date_generators.hpp
@@ -13,8 +13,8 @@
   Definition and implementation of date algorithm templates
 */
 
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <boost/throw_exception.hpp>
 #include <boost/date_time/date.hpp>
 #include <boost/date_time/compiler_config.hpp>
@@ -38,7 +38,7 @@ namespace date_time {
     virtual ~year_based_generator() {}
     virtual date_type get_date(year_type y) const = 0;
     //! Returns a string for use in a POSIX time_zone string
-    virtual std::string to_string() const =0;
+    virtual std::string to_string() const = 0;
   };
 
   //! Generates a date by applying the year to the given month and day.
@@ -98,7 +98,7 @@ namespace date_time {
     * pg.get_date(2000); // returns 2000-2-29
     * @endcode
          */
-   date_type get_date(year_type y) const
+   date_type get_date(year_type y) const BOOST_OVERRIDE
    {
      if((day_ == 29) && (month_ == 2) && !(calendar_type::is_leap_year(y))) {
        std::ostringstream ss;
@@ -139,7 +139,7 @@ namespace date_time {
     * Jan-01 == "0"
     * Feb-29 == "58"
     * Dec-31 == "365" */
-   virtual std::string to_string() const
+   std::string to_string() const BOOST_OVERRIDE
    {
      std::ostringstream ss;
      date_type d(2004, month_, day_);
@@ -176,7 +176,7 @@ namespace date_time {
    *  The algorithm here basically guesses for the first
    *  day of the month.  Then finds the first day of the correct
    *  type.  That is, if the first of the month is a Tuesday
-   *  and it needs Wenesday then we simply increment by a day
+   *  and it needs Wednesday then we simply increment by a day
    *  and then we can add the length of a week until we get
    *  to the 'nth kday'.  There are probably more efficient
    *  algorithms based on using a mod 7, but this one works
@@ -201,7 +201,7 @@ namespace date_time {
       dow_(dow)
     {}
     //! Return a concrete date when provided with a year specific year.
-    date_type get_date(year_type y) const
+    date_type get_date(year_type y) const BOOST_OVERRIDE
     {
       date_type d(y, month_, 1); //first day of month
       duration_type one_day(1);
@@ -239,7 +239,7 @@ namespace date_time {
     }
     //! Returns string suitable for use in POSIX time zone string
     /*! Returns a string formatted as "M4.3.0" ==> 3rd Sunday in April. */
-    virtual std::string to_string() const
+    std::string to_string() const BOOST_OVERRIDE
     {
      std::ostringstream ss;
      ss << 'M'
@@ -276,7 +276,7 @@ namespace date_time {
       dow_(dow)
     {}
     //! Return a concrete date when provided with a year specific year.
-    date_type get_date(year_type year) const
+    date_type get_date(year_type year) const BOOST_OVERRIDE
     {
       date_type d(year, month_,1);
       duration_type one_day(1);
@@ -296,7 +296,7 @@ namespace date_time {
     }
     //! Returns string suitable for use in POSIX time zone string
     /*! Returns a string formatted as "M4.1.0" ==> 1st Sunday in April. */
-    virtual std::string to_string() const
+    std::string to_string() const BOOST_OVERRIDE
     {
      std::ostringstream ss;
      ss << 'M'
@@ -337,7 +337,7 @@ namespace date_time {
       dow_(dow)
     {}
     //! Return a concrete date when provided with a year specific year.
-    date_type get_date(year_type year) const
+    date_type get_date(year_type year) const BOOST_OVERRIDE
     {
       date_type d(year, month_, calendar_type::end_of_month_day(year,month_));
       duration_type one_day(1);
@@ -357,7 +357,7 @@ namespace date_time {
     }
     //! Returns string suitable for use in POSIX time zone string
     /*! Returns a string formatted as "M4.5.0" ==> last Sunday in April. */
-    virtual std::string to_string() const
+    std::string to_string() const BOOST_OVERRIDE
     {
       std::ostringstream ss;
       ss << 'M'
@@ -511,8 +511,4 @@ namespace date_time {
 
 } } //namespace date_time
 
-
-
-
 #endif
-

--- a/include/boost/date_time/gregorian_calendar.ipp
+++ b/include/boost/date_time/gregorian_calendar.ipp
@@ -189,7 +189,7 @@ namespace date_time {
         return 29;
       } else {
         return 28;
-      };
+      }
     case 4:
     case 6:
     case 9:
@@ -197,11 +197,10 @@ namespace date_time {
       return 30;
     default:
       return 31;
-    };
-
+    }
   }
 
-  //! Provide the ymd_type specification for the calandar start
+  //! Provide the ymd_type specification for the calendar start
   template<typename ymd_type_, typename date_int_type_>
   BOOST_CXX14_CONSTEXPR
   inline
@@ -223,5 +222,3 @@ namespace date_time {
 
 
 } } //namespace gregorian
-
-

--- a/include/boost/date_time/time_facet.hpp
+++ b/include/boost/date_time/time_facet.hpp
@@ -11,13 +11,13 @@
  */
 
 #include <cctype>
-#include <locale>
-#include <limits>
-#include <string>
-#include <sstream>
+#include <exception>
 #include <iomanip>
 #include <iterator> // i/ostreambuf_iterator
-#include <exception>
+#include <locale>
+#include <limits>
+#include <sstream>
+#include <string>
 #include <boost/assert.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
@@ -269,11 +269,11 @@ namespace date_time {
       m_time_duration_format = format;
     }
 
-    virtual void set_iso_format()
+    void set_iso_format() BOOST_OVERRIDE
     {
       this->m_format = iso_time_format_specifier;
     }
-    virtual void set_iso_extended_format()
+    void set_iso_extended_format() BOOST_OVERRIDE
     {
       this->m_format = iso_time_format_extended_specifier;
     }
@@ -409,7 +409,7 @@ namespace date_time {
         // replace %F with nnnnnnn or nothing if fs == 0
         frac_str =
           fractional_seconds_as_string(time_arg.time_of_day(), true);
-        if (frac_str.size()) {
+        if (!frac_str.empty()) {
           char_type sep = std::use_facet<std::numpunct<char_type> >(ios_arg.getloc()).decimal_point();
           string_type replace_string;
           replace_string += sep;
@@ -958,7 +958,7 @@ namespace date_time {
         while((sitr != stream_end) && std::isspace(*sitr)) { ++sitr; }
 
         bool use_current_char = false;
-        bool use_current_format_char = false; // used whith two character flags
+        bool use_current_format_char = false; // used with two character flags
 
         // num_get will consume the +/-, we may need a copy if special_value
         char_type c = '\0';
@@ -1365,9 +1365,6 @@ template <class time_type, class CharT, class InItrT>
   const typename time_input_facet<time_type, CharT, InItrT>::char_type*
   time_input_facet<time_type, CharT, InItrT>::default_time_duration_format = time_formats<CharT>::default_time_duration_format;
 
-
 } } // namespaces
 
-
 #endif
-

--- a/include/boost/date_time/time_parsing.hpp
+++ b/include/boost/date_time/time_parsing.hpp
@@ -21,7 +21,7 @@ namespace date_time {
 
   //! computes exponential math like 2^8 => 256, only works with positive integers
   //Not general purpose, but needed b/c std::pow is not available 
-  //everywehere. Hasn't been tested with negatives and zeros
+  //everywhere. Hasn't been tested with negatives and zeros
   template<class int_type>
   inline
   int_type power(int_type base, int_type exponent)
@@ -79,7 +79,7 @@ namespace date_time {
       case 2: {
         sec = boost::lexical_cast<unsigned short>(*beg);
         break;
-      };
+      }
       case 3: {
         int digits = static_cast<int>(beg->length());
         //Works around a bug in MSVC 6 library that does not support
@@ -284,7 +284,7 @@ namespace date_time {
             break;
           }
           default: break;
-      };
+      }
       pos++;
     }
     if(sign) {
@@ -334,11 +334,6 @@ namespace date_time {
     return time_type(d, td);
   }
 
-
-
 } }//namespace date_time
-
-
-
 
 #endif


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Also fix Clang -Wextra-semi-stmt and Clang-tidy readability-container-size-empty warnings.
Alphabetical order of STL headers.
Fix some misspellings.