### PR TITLE
Fix clang 10 C++17 warnings about deprecated implicit assignment operators

### DIFF
--- a/include/boost/date_time/date_duration.hpp
+++ b/include/boost/date_time/date_duration.hpp
@@ -42,12 +42,6 @@ namespace date_time {
             days_(duration_rep::from_special(sv))
     {}
 
-    // copy constructor required for addable<> & subtractable<>
-    //! Construct from another date_duration (Copy Constructor)
-    BOOST_CXX14_CONSTEXPR date_duration(const date_duration<duration_rep_traits>& other) :
-            days_(other.days_)
-    {}
-
     //! returns days_ as it's instantiated type - used for streaming
     BOOST_CXX14_CONSTEXPR duration_rep get_rep()const
     {

--- a/include/boost/date_time/gregorian/greg_duration.hpp
+++ b/include/boost/date_time/gregorian/greg_duration.hpp
@@ -39,11 +39,6 @@ namespace gregorian {
     BOOST_CXX14_CONSTEXPR
     date_duration(date_time::special_values sv) : base_type(sv) {}
 
-    //! Copy constructor
-    BOOST_CXX14_CONSTEXPR
-    date_duration(const date_duration& other) : base_type(static_cast< base_type const& >(other))
-    {}
-
     //! Construct from another date_duration
     BOOST_CXX14_CONSTEXPR
     date_duration(const base_type& other) : base_type(other)

--- a/include/boost/date_time/period_parser.hpp
+++ b/include/boost/date_time/period_parser.hpp
@@ -69,12 +69,6 @@ namespace boost { namespace date_time {
       delimiters.push_back(string_type(period_closed_range_end_delimeter));
     }
 
-    period_parser(const period_parser<date_type,CharT>& p_parser)
-    {
-      this->delimiters = p_parser.delimiters;
-      this->m_range_option = p_parser.m_range_option;
-    }
-
     period_range_option range_option() const
     {
       return m_range_option;

--- a/include/boost/date_time/special_values_parser.hpp
+++ b/include/boost/date_time/special_values_parser.hpp
@@ -75,11 +75,6 @@ namespace boost { namespace date_time {
       m_sv_strings = parse_tree_type(phrases, static_cast<int>(not_a_date_time));
     }
 
-    special_values_parser(const special_values_parser<date_type,charT>& svp)
-    {
-      this->m_sv_strings = svp.m_sv_strings;
-    }
-
     //! Replace special value strings
     void sv_strings(const string_type& nadt_str,
                     const string_type& neg_inf_str,

--- a/include/boost/date_time/time_duration.hpp
+++ b/include/boost/date_time/time_duration.hpp
@@ -63,11 +63,6 @@ namespace date_time {
                   fractional_seconds_type frac_sec_in = 0) :
       ticks_(rep_type::to_tick_count(hours_in,minutes_in,seconds_in,frac_sec_in))
     {}
-    // copy constructor required for dividable<>
-    //! Construct from another time_duration (Copy constructor)
-    BOOST_CXX14_CONSTEXPR time_duration(const time_duration<T, rep_type>& other)
-      : ticks_(other.ticks_)
-    {}
     //! Construct from special_values
     BOOST_CXX14_CONSTEXPR time_duration(special_values sv) : ticks_(impl_type::from_special(sv))
     {}


### PR DESCRIPTION
C++17 deprecates implicit generation of assignment operator in presence of explicitly declared copy constructor. In future standards this behavior may be removed.

In the affected Boost.DateTime classes, the explicitly defined copy constructors are functionally equivalent to those would be generated implicitly, so we can just remove them. The additional benefit is that the implicitly generated ones will have `constexpr` and `noexcept` specifications, and will also allow implicit move constructors and assignment operators.

The warnings can be reproduced with this command line:

```
b2 -j8 toolset=clang cxxstd=17 warnings=extra
```

For example:

```
../../../boost/date_time/date_duration.hpp:47:27: warning: definition of implicit copy assignment operator for 'date_duration<boost::date_time::duration_traits_adapted>' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
    BOOST_CXX14_CONSTEXPR date_duration(const date_duration<duration_rep_traits>& other) :
                          ^
../../../boost/date_time/gregorian/greg_duration.hpp:26:30: note: in implicit copy assignment operator for 'boost::date_time::date_duration<boost::date_time::duration_traits_adapted>' first required here
  class BOOST_SYMBOL_VISIBLE date_duration :
                             ^
gregorian/testdate_duration.cpp:44:10: note: in implicit copy assignment operator for 'boost::gregorian::date_duration' first required here
  oneDay = twoDays / 2;
         ^
```

After the fix, a few similar warnings from Boost.Serialization may be left.
