### PR TITLE
Add BOOST_CXX14_CONSTEXPR to CV assign()

### DIFF
--- a/include/boost/date_time/constrained_value.hpp
+++ b/include/boost/date_time/constrained_value.hpp
@@ -65,7 +65,7 @@ namespace CV {
   protected:
     value_type value_;
   private:
-    void assign(value_type value)
+    BOOST_CXX14_CONSTEXPR void assign(value_type value)
     {
       //adding 1 below gets rid of a compiler warning which occurs when the 
       //min_value is 0 and the type is unsigned....


### PR DESCRIPTION
Without this change the BOOST_CXX14_CONSTEXPR on the constructors has no
effect, as they invoke assign()