### PR TITLE
add constexpr tests to date, ptime, constrained_value

### DIFF
--- a/test/gregorian/testdate.cpp
+++ b/test/gregorian/testdate.cpp
@@ -34,6 +34,25 @@ main()
   date def;
   check("Default constructor", def == date(not_a_date_time));
 #endif
+
+#ifdef BOOST_NO_CXX14_CONSTEXPR
+  check("constexpr not configured", true);
+#else  
+  //check constexpr case
+  {
+    constexpr date d1(1900,1,1);
+    static_assert(d1.day() == 1,     "constexpr construction day()");
+    static_assert(d1.month() == 1,   "constexpr construction month()");
+    static_assert(d1.year() == 1900, "constexpr construction year()");
+    constexpr date d2 = date(2000,12,31);
+    constexpr date d3(d2);
+    static_assert(d3.day() == 31,      "constexpr construct and copy day()");
+    static_assert(d3.month() == 12,    "constexpr construct and copy month()");
+    static_assert(d3.year() == 2000,   "constexpr construct and copy year()");
+    check("constexpr tests compiled", true);    
+  }
+#endif
+
   
   date d1(1900,1,1);
   date d2 = date(2000,1,1);

--- a/test/posix_time/testtime.cpp
+++ b/test/posix_time/testtime.cpp
@@ -29,6 +29,28 @@ void special_values_tests()
   }
 #endif // DATE_TIME_NO_DEFAULT_CONSTRUCTOR
 
+#ifdef BOOST_NO_CXX14_CONSTEXPR
+  check("constexpr not configured", true);
+#else  
+  //check constexpr case
+  {
+    constexpr date d1(1970,1,1);
+    constexpr ptime t1(d1);
+    static_assert(t1.date().day() == 1,     "constexpr construction day()");
+    static_assert(t1.date().month() == 1,   "constexpr construction month()");
+    static_assert(t1.date().year() == 1970, "constexpr construction year()");
+    static_assert(t1.time_of_day().hours() == 0,   "constexpr construction hour()");
+    static_assert(t1.time_of_day().minutes() == 0, "constexpr construction minute()");
+    static_assert(t1.time_of_day().seconds() == 0,   "constexpr construction second()");
+    constexpr ptime t2(d1, time_duration(1,2,3));
+    static_assert(t2.time_of_day().hours() == 1,    "constexpr contruct with duration  hour()");
+    static_assert(t2.time_of_day().minutes() == 2,  "constexpr contruct with duration  minute()");
+    static_assert(t2.time_of_day().seconds() == 3,  "constexpr contruct with duration  second()");
+    check("constexpr tests compiled", true);    
+  }
+#endif
+
+  
   { // special values construction tests
     ptime p_sv1(pos_infin);
     std::string s("+infinity");

--- a/test/testconstrained_value.cpp
+++ b/test/testconstrained_value.cpp
@@ -17,8 +17,8 @@ class day_value_policies
 {
 public:
   typedef unsigned int value_type;
-  static unsigned int min BOOST_PREVENT_MACRO_SUBSTITUTION () { return 0; };
-  static unsigned int max BOOST_PREVENT_MACRO_SUBSTITUTION () { return 31;};
+  static BOOST_CXX14_CONSTEXPR unsigned int min BOOST_PREVENT_MACRO_SUBSTITUTION () { return 0; };
+  static BOOST_CXX14_CONSTEXPR unsigned int max BOOST_PREVENT_MACRO_SUBSTITUTION () { return 31;};
   static void on_error(unsigned int&, unsigned int, boost::CV::violation_enum)
   {
     throw bad_day();
@@ -41,6 +41,14 @@ int main()
   unsigned int i = cv1; 
   check("test conversion", i == cv1);
 
+#ifdef BOOST_NO_CXX14_CONSTEXPR
+  check("constexpr not configured", true);
+#else  
+  //check constexpr case
+  constexpr constrained_value<day_value_policies> cv3(1);
+  static_assert(cv3 == 1, "constexpr construction/conversion");
+  check("constexpr constrained value construct and equal", true);
+#endif
 
   try {
     constrained_value<one_to_ten_range_policy> cv3(11);


### PR DESCRIPTION
Add some compile tests for constexpr changes to ensure compile time resolution. 