### PR TITLE
Add missing include

### DIFF
--- a/include/boost/date_time/dst_rules.hpp
+++ b/include/boost/date_time/dst_rules.hpp
@@ -16,6 +16,7 @@
 #include "boost/date_time/date_generators.hpp"
 #include "boost/date_time/period.hpp"
 #include "boost/date_time/date_defs.hpp"
+#include "boost/date_time/gregorian/gregorian.hpp"
 #include <stdexcept>
 
 namespace boost {


### PR DESCRIPTION
Allow header file to be built standalone, making possible C++ clang modules builds.