### PR TITLE
This fixes the Visual Studio 2019 warning W26451

### DIFF
--- a/include/boost/date_time/microsec_time_clock.hpp
+++ b/include/boost/date_time/microsec_time_clock.hpp
@@ -122,7 +122,7 @@ namespace date_time {
       time_duration_type td(static_cast< typename time_duration_type::hour_type >(curr_ptr->tm_hour),
                             static_cast< typename time_duration_type::min_type >(curr_ptr->tm_min),
                             static_cast< typename time_duration_type::sec_type >(curr_ptr->tm_sec),
-                            sub_sec * adjust);
+                            static_cast< typename time_duration_type::fractional_seconds_type >(sub_sec) * adjust);
 
       return time_type(d,td);
     }


### PR DESCRIPTION
Please consider this small fix to avoid a Visual Studio warning.
(Arithmetic overflow Using operator* on a 4 byte value and then casting the result to a 8 byte value.)