### PR TITLE
 fix signed to unsigned conversion warning

### DIFF
--- a/include/boost/date_time/gregorian_calendar.ipp
+++ b/include/boost/date_time/gregorian_calendar.ipp
@@ -77,7 +77,7 @@ namespace date_time {
     unsigned short a = static_cast<unsigned short>((14-ymd.month)/12);
     unsigned short y = static_cast<unsigned short>(ymd.year + 4800 - a);
     unsigned short m = static_cast<unsigned short>(ymd.month + 12*a - 3);
-    unsigned long  d = ymd.day + ((153*m + 2)/5) + 365*y + (y/4) - (y/100) + (y/400) - 32045;
+    unsigned long  d = static_cast<unsigned long>(ymd.day) + ((153*m + 2)/5) + 365*y + (y/4) - (y/100) + (y/400) - 32045;
     return static_cast<date_int_type>(d);
   }
 


### PR DESCRIPTION
MSVC 19.28.29336.0 throws the following warning when
boost::date_time::gregorian_date is called.

warning C4365: 'initializing': conversion from 'int' to 'unsigned long', signed/unsigned mismatch
warning C4365: const boost::posix_time::ptime Since1970(boost::gregorian::date(1970U, 1U, 1U));
warning C4365:                                                                                ^
<path>\include\boost\date_time\date.hpp(72,35): message : while evaluating constexpr function 'boost::date_time::gregorian_calendar_base<boost::gregorian::greg_year_month_day,unsigned int>::day_number'
<path>\include\boost\date_time\date.hpp(72,35): message :       : days_(calendar::day_number(ymd_type(y, m, d)))