### PR TITLE
ptime from iso error string error with date only

### DIFF
--- a/include/boost/date_time/compiler_config.hpp
+++ b/include/boost/date_time/compiler_config.hpp
@@ -28,10 +28,6 @@
 
 // Include extensions to date_duration - comment out to remove this feature
 #define BOOST_DATE_TIME_OPTIONAL_GREGORIAN_TYPES
-// these extensions are known to cause problems with gcc295
-#if defined(__GNUC__) && (__GNUC__ < 3)
-#undef BOOST_DATE_TIME_OPTIONAL_GREGORIAN_TYPES
-#endif
 
 #if (defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION) || BOOST_WORKAROUND( BOOST_BORLANDC,  BOOST_TESTED_AT(0x581) ) )
 #define BOOST_DATE_TIME_NO_MEMBER_INIT
@@ -123,26 +119,6 @@ namespace std {
 #  define BOOST_DATE_TIME_DECL
 #endif
 
-//
-// Automatically link to the correct build variant where possible. 
-// 
-#if !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_DATE_TIME_NO_LIB) && !defined(BOOST_DATE_TIME_SOURCE)
-//
-// Set the name of our library, this will get undef'ed by auto_link.hpp
-// once it's done with it:
-//
-#define BOOST_LIB_NAME boost_date_time
-//
-// If we're importing code from a dll, then tell auto_link.hpp about it:
-//
-#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_DATE_TIME_DYN_LINK)
-#  define BOOST_DYN_LINK
-#endif
-//
-// And include the header that does the work:
-//
-#include <boost/config/auto_link.hpp>
-#endif  // auto-linking disabled
 
 #if defined(BOOST_HAS_THREADS) 
 #  if defined(_MSC_VER) || defined(__MWERKS__) || defined(__MINGW32__) ||  defined(__BORLANDC__)

--- a/include/boost/date_time/posix_time/time_parsers.hpp
+++ b/include/boost/date_time/posix_time/time_parsers.hpp
@@ -36,6 +36,10 @@ namespace posix_time {
   }
 
   inline ptime from_iso_extended_string(const std::string& s) {
+    if (s.size() == 10) { //assume we just have a date which is 10 chars
+      gregorian::date d = gregorian::from_simple_string(s);
+      return ptime( d );
+    }
     return date_time::parse_delimited_time<ptime>(s, 'T');
   }
 

--- a/test/posix_time/testparse_time.cpp
+++ b/test/posix_time/testparse_time.cpp
@@ -220,6 +220,8 @@ main()
     ptime t27 = from_iso_extended_string(ts10);
     check("parse iso extended time w/ frac sec (dec only): " + ts10,
           t27 == ptime(date(1900,12,31),time_duration(23,0,0,0)));
+
+
 #else
     std::string ts3("20020120T235859.123456");
     ptime t20 = from_iso_string(ts3);
@@ -260,6 +262,35 @@ main()
     ptime t27 = from_iso_extended_string(ts10);
     check("parse iso extended time w/ frac sec (dec only): " + ts10,
           t27 == ptime(date(1900,12,31),time_duration(23,0,0,0)));
+
+    //the following test cases are for this issue:
+    //https://github.com/boostorg/date_time/issues/187
+    try {
+      std::string ts11("1900-12-31"); //date only string
+      ptime t28 = from_iso_extended_string(ts11);
+      check("parse iso extended time date only): " + ts11,
+            t28 == ptime(date(1900,12,31),time_duration(0,0,0,0)));
+    }
+    catch( std::exception& e )
+    {
+      std::cout << e.what() << std::endl;
+      check("parse iso extended time date only): 1900-12-32", false);
+    }
+
+    try {
+      //expect a date-time exception here
+      std::string ts12("1900-1"); //completely bogus string
+      ptime t29 = from_iso_extended_string(ts12);
+      check("parse iso extended time bad string: " + ts12, false);
+      (void) t29; //supress unused compiler warning, this is never reached
+    }
+    catch( std::exception& e )
+    {
+      //Day of month value is out of range 1..31
+      // std::cout << e.what() << std::endl;
+      check("parse iso extended time date only): 1900-1", true);
+    }
+
 #endif // BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
   }
 


### PR DESCRIPTION
fix one case -- check the error handling doesn't dip into std::string out of range.