### PR TITLE
Fix typo in time_period end() example

### DIFF
--- a/xmldoc/time_period.xml
+++ b/xmldoc/time_period.xml
@@ -191,7 +191,7 @@ tp.last();// --> 2002-Jan-01 09:59:59.999999999</screen>
 ptime t1(d, seconds(10)); //10 sec after midnight
 ptime t2(d, hours(10)); //10 hours after midnight
 time_period tp(t1, t2);
-tp.last(); // --> 2002-Jan-01 10:00:00</screen>
+tp.end(); // --> 2002-Jan-01 10:00:00</screen>
 	    </entry>
           </row>
           


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27598913/176959945-ccfaeb38-6653-468d-98b7-0f1546fcf81c.png)

Highlighted is the typo, this should be tp.end() not tp.last(), as this is an example of the behavior of the end() accessor. I've tested these functions and have confirmed the behavior matches the example.