### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
           # OSX, clang
           # sanitize disabled: there are too many issues in serialization and not enough time to add suppressions
-          - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-10.15 }
+          - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-11 }
 
           # Coverity Scan
           # requires two github secrets in repo to activate; see ci/github/coverity.sh


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22