### PR TITLE
Fix constexpr of gregorian::date::date(special_values) to improve perf

### DIFF
--- a/include/boost/date_time/gregorian/greg_date.hpp
+++ b/include/boost/date_time/gregorian/greg_date.hpp
@@ -74,18 +74,8 @@ namespace gregorian {
     {}
     //! Constructor for infinities, not a date, max and min date
     BOOST_CXX14_CONSTEXPR explicit date(special_values sv):
-      date_time::date<date, gregorian_calendar, date_duration>(date_rep_type::from_special(sv))
-    {
-      if (sv == min_date_time)
-      {
-        *this = date(1400, 1, 1);
-      }
-      if (sv == max_date_time)
-      {
-        *this = date(9999, 12, 31);
-      }
-
-    }
+      date_time::date<date, gregorian_calendar, date_duration>(from_special_adjusted(sv))
+    {}
     //!Return the Julian Day number for the date.
     BOOST_CXX14_CONSTEXPR date_int_type julian_day() const
     {
@@ -129,6 +119,15 @@ namespace gregorian {
 
    private:
 
+    BOOST_CXX14_CONSTEXPR date_rep_type from_special_adjusted(special_values sv)
+    {
+      switch (sv)
+      {
+        case min_date_time: return gregorian_calendar::day_number(ymd_type(1400, 1, 1));
+        case max_date_time: return gregorian_calendar::day_number(ymd_type(9999, 12, 31));
+        default: return date_rep_type::from_special(sv);
+      }
+    }
   };
 
   inline BOOST_CXX14_CONSTEXPR


### PR DESCRIPTION
Fixes #121 

Turns out even when all functions without the library are prefixed with constexpr, GCC up to at least v10 does not consider this constructor as constexpr at least when generating code.
```
BOOST_CXX14_CONSTEXPR explicit date(special_values sv):
      date_time::date<date, gregorian_calendar, date_duration>(date_rep_type::from_special(sv))
    {
      if (sv == min_date_time)
      {
        *this = date(1400, 1, 1);
      }
      if (sv == max_date_time)
      {
        *this = date(9999, 12, 31);
      }
    }
```

The culprit is the assignment to `*this`. Refactoring the code to initialize the instance just once improves code generation significantly. Note that clang since at least v11 does not exhibit this problem.