### PR TITLE
Iso doc fixes

### DIFF
--- a/example/gregorian/dates_as_strings.cpp
+++ b/example/gregorian/dates_as_strings.cpp
@@ -25,7 +25,7 @@ main()
     date d(from_simple_string(s));
     std::cout << to_simple_string(d) << std::endl;
     
-    //Read ISO Standard(CCYYMMDD) and output ISO Extended
+    //Read ISO 8601 Standard(CCYYMMDD) and output ISO 8601 Extended
     std::string ud("20011009"); //2001-Oct-09
     date d1(from_undelimited_string(ud));
     std::cout << to_iso_extended_string(d1) << std::endl;

--- a/example/gregorian/localization.cpp
+++ b/example/gregorian/localization.cpp
@@ -83,7 +83,7 @@ int main()
   us_facet->format("%m/%d/%Y");
   std::cout << d1 << std::endl; //  10/01/2002
   
-  // English names, iso order (year-month-day), '-' separator
+  // English names, ISO 8601 order (year-month-day), '-' separator
   us_facet->format("%Y-%b-%d");
   std::cout << d1 << std::endl; //  2002-Oct-01
   

--- a/include/boost/date_time/date.hpp
+++ b/include/boost/date_time/date.hpp
@@ -21,7 +21,7 @@ namespace date_time {
   /*!
     The date template represents an interface shell for a date class
     that is based on a year-month-day system such as the gregorian
-    or iso systems.  It provides basic operations to enable calculation
+    or ISO 8601 systems.  It provides basic operations to enable calculation
     and comparisons.
 
     <b>Theory</b>

--- a/include/boost/date_time/gregorian/formatters.hpp
+++ b/include/boost/date_time/gregorian/formatters.hpp
@@ -65,7 +65,7 @@ namespace gregorian {
     std::basic_string<charT> s(date_time::date_formatter<date,date_time::iso_format<charT>,charT>::date_to_string(d.begin()));
     return s + sep + date_time::date_formatter<date,date_time::iso_format<charT>,charT>::date_to_string(d.last());
   }
-  //! Date period to iso standard format CCYYMMDD/CCYYMMDD. Example: 20021225/20021231
+  //! Date period to ISO 8601 standard format CCYYMMDD/CCYYMMDD. Example: 20021225/20021231
   /*!\ingroup date_format
    */
   inline std::string to_iso_string(const date_period& d) {
@@ -78,7 +78,7 @@ namespace gregorian {
   inline std::basic_string<charT> to_iso_extended_string_type(const date& d) {
     return date_time::date_formatter<date,date_time::iso_extended_format<charT>,charT>::date_to_string(d);
   }
-  //! Convert to iso extended format string CCYY-MM-DD. Example 2002-12-31
+  //! Convert to ISO 8601 extended format string CCYY-MM-DD. Example 2002-12-31
   /*!\ingroup date_format
    */
   inline std::string to_iso_extended_string(const date& d) {
@@ -90,7 +90,7 @@ namespace gregorian {
   inline std::basic_string<charT> to_iso_string_type(const date& d) {
     return date_time::date_formatter<date,date_time::iso_format<charT>,charT>::date_to_string(d);
   }
-  //! Convert to iso standard string YYYYMMDD. Example: 20021231
+  //! Convert to ISO 8601 standard string YYYYMMDD. Example: 20021231
   /*!\ingroup date_format
    */
   inline std::string to_iso_string(const date& d) {

--- a/include/boost/date_time/gregorian/formatters_limited.hpp
+++ b/include/boost/date_time/gregorian/formatters_limited.hpp
@@ -35,7 +35,7 @@ namespace gregorian {
     return std::string("[" + d1 + "/" + d2 + "]");
   }
 
-  //! Date period to iso standard format CCYYMMDD/CCYYMMDD. Example: 20021225/20021231
+  //! Date period to ISO 8601 standard format CCYYMMDD/CCYYMMDD. Example: 20021225/20021231
   /*!\ingroup date_format
    */
   inline std::string to_iso_string(const date_period& d) {
@@ -44,14 +44,14 @@ namespace gregorian {
   }
 
 
-  //! Convert to iso extended format string CCYY-MM-DD. Example 2002-12-31
+  //! Convert to ISO 8601 extended format string CCYY-MM-DD. Example 2002-12-31
   /*!\ingroup date_format
    */
   inline std::string to_iso_extended_string(const date& d) {
     return date_time::date_formatter<date,date_time::iso_extended_format<char> >::date_to_string(d);
   }
 
-  //! Convert to iso standard string YYYYMMDD. Example: 20021231
+  //! Convert to ISO 8601 standard string YYYYMMDD. Example: 20021231
   /*!\ingroup date_format
    */
   inline std::string to_iso_string(const date& d) {

--- a/include/boost/date_time/gregorian/greg_date.hpp
+++ b/include/boost/date_time/gregorian/greg_date.hpp
@@ -95,7 +95,7 @@ namespace gregorian {
       ymd_type ymd = year_month_day();
       return gregorian_calendar::modjulian_day_number(ymd);
     }
-    //!Return the iso 8601 week number 1..53
+    //!Return the ISO 8601 week number 1..53
     BOOST_CXX14_CONSTEXPR int week_number() const
     {
       ymd_type ymd = year_month_day();

--- a/include/boost/date_time/gregorian/parsers.hpp
+++ b/include/boost/date_time/gregorian/parsers.hpp
@@ -64,12 +64,12 @@ namespace gregorian {
     return date_time::parse_date<date>(s, date_time::ymd_order_dmy);
   }
   
-  //! From iso type date string where with order year-month-day eg: 20020125
+  //! From ISO 8601 type date string where with order year-month-day eg: 20020125
   inline date from_undelimited_string(const std::string& s) {
     return date_time::parse_undelimited_date<date>(s);
   }
 
-  //! From iso type date string where with order year-month-day eg: 20020125
+  //! From ISO 8601 type date string where with order year-month-day eg: 20020125
   inline date date_from_iso_string(const std::string& s) {
     return date_time::parse_undelimited_date<date>(s);
   }

--- a/include/boost/date_time/gregorian_calendar.ipp
+++ b/include/boost/date_time/gregorian_calendar.ipp
@@ -25,8 +25,8 @@ namespace date_time {
     return d;
   }
 
-  //!Return the iso week number for the date
-  /*!Implements the rules associated with the iso 8601 week number.
+  //!Return the ISO 8601 week number for the date
+  /*!Implements the rules associated with the ISO 8601 week number.
     Basically the rule is that Week 1 of the year is the week that contains
     January 4th or the week that contains the first Thursday in January.
     Reference for this algorithm is the Calendar FAQ by Claus Tondering, April 2000.

--- a/include/boost/date_time/iso_format.hpp
+++ b/include/boost/date_time/iso_format.hpp
@@ -14,11 +14,11 @@
 namespace boost {
 namespace date_time {
 
-//! Class to provide common iso formatting spec
+//! Class to provide common ISO 8601 formatting spec
 template<class charT>
 class iso_format_base {
 public:
-  //! Describe month format -- its an integer in iso format
+  //! Describe month format -- its an integer in ISO 8601 format
   static month_format_spec month_format()
   {
     return month_as_integer;
@@ -40,17 +40,17 @@ public:
     return "-infinity";
   }
 
-  //! ISO char for a year -- used in durations
+  //! ISO 8601 char for a year -- used in durations
   static charT year_sep_char()
   {
     return 'Y';
   }
-  //! ISO char for a month
+  //! ISO 8601 char for a month
   static charT month_sep_char()
   {
     return '-';
   }
-  //! ISO char for a day
+  //! ISO 8601 char for a day
   static charT day_sep_char()
   {
     return '-';
@@ -70,7 +70,7 @@ public:
   {
     return ':';
   }
-  //! ISO char for a period
+  //! ISO 8601 char for a period
   static charT period_start_char()
   {
     return 'P';
@@ -143,11 +143,11 @@ public:
 
 #ifndef BOOST_NO_STD_WSTRING
 
-//! Class to provide common iso formatting spec
+//! Class to provide common ISO 8601 formatting spec
 template<>
 class iso_format_base<wchar_t> {
 public:
-  //! Describe month format -- its an integer in iso format
+  //! Describe month format -- its an integer in ISO 8601 format
   static month_format_spec month_format()
   {
     return month_as_integer;
@@ -169,17 +169,17 @@ public:
     return L"-infinity";
   }
 
-  //! ISO char for a year -- used in durations
+  //! ISO 8601 char for a year -- used in durations
   static wchar_t year_sep_char()
   {
     return 'Y';
   }
-  //! ISO char for a month
+  //! ISO 8601 char for a month
   static wchar_t month_sep_char()
   {
     return '-';
   }
-  //! ISO char for a day
+  //! ISO 8601 char for a day
   static wchar_t day_sep_char()
   {
     return '-';
@@ -199,7 +199,7 @@ public:
   {
     return ':';
   }
-  //! ISO char for a period
+  //! ISO 8601 char for a period
   static wchar_t period_start_char()
   {
     return 'P';
@@ -272,7 +272,7 @@ public:
 
 #endif // BOOST_NO_STD_WSTRING
 
-//! Format description for iso normal YYYYMMDD
+//! Format description for ISO 8601 normal YYYYMMDD
 template<class charT>
 class iso_format : public iso_format_base<charT> {
 public:

--- a/include/boost/date_time/local_time/local_date_time.hpp
+++ b/include/boost/date_time/local_time/local_date_time.hpp
@@ -315,7 +315,7 @@ namespace local_time {
 
     //! Returns name of associated time zone or "Coordinated Universal Time".
     /*! Optional bool parameter will return time zone as an offset
-     * (ie "+07:00" extended iso format). Empty string is returned for
+     * (ie "+07:00" extended ISO 8601 format). Empty string is returned for
      * classes that do not use a time_zone */
     std::string zone_name(bool as_offset=false) const
     {
@@ -349,7 +349,7 @@ namespace local_time {
     }
     //! Returns abbreviation of associated time zone or "UTC".
     /*! Optional bool parameter will return time zone as an offset
-     * (ie "+0700" iso format). Empty string is returned for classes
+     * (ie "+0700" ISO 8601 format). Empty string is returned for classes
      * that do not use a time_zone */
     std::string zone_abbrev(bool as_offset=false) const
     {

--- a/include/boost/date_time/posix_time/time_formatters.hpp
+++ b/include/boost/date_time/posix_time/time_formatters.hpp
@@ -157,7 +157,7 @@ namespace posix_time {
     }// else
     return ss.str();
   }
-  //! Time duration in iso format -hhmmss.fffffff. Example: 10:09:03.0123456
+  //! Time duration in ISO 8601 format -hhmmss.fffffff. Example: 10:09:03.0123456
   /*!\ingroup time_format
    */
   inline std::string to_iso_string(time_duration td){
@@ -215,7 +215,7 @@ namespace posix_time {
       return ts;
     }
   }
-  //! Convert iso short form YYYYMMDDTHHMMSS where T is the date-time separator
+  //! Convert ISO 8601 short form YYYYMMDDTHHMMSS where T is the date-time separator
   /*!\ingroup time_format
    */
   inline std::string to_iso_string(ptime t){
@@ -251,7 +251,7 @@ namespace posix_time {
   inline std::wstring to_simple_wstring(time_duration td) {
     return to_simple_string_type<wchar_t>(td);
   }
-  //! Time duration in iso format -hhmmss.fffffff. Example: 10:09:03.0123456
+  //! Time duration in ISO 8601 format -hhmmss.fffffff. Example: 10:09:03.0123456
   /*!\ingroup time_format
    */
   inline std::wstring to_iso_wstring(time_duration td){
@@ -266,7 +266,7 @@ namespace posix_time {
   inline std::wstring to_simple_wstring(time_period tp){
     return to_simple_string_type<wchar_t>(tp);
   }
-  //! Convert iso short form YYYYMMDDTHHMMSS where T is the date-time separator
+  //! Convert ISO 8601 short form YYYYMMDDTHHMMSS where T is the date-time separator
   /*!\ingroup time_format
    */
   inline std::wstring to_iso_wstring(ptime t){

--- a/include/boost/date_time/posix_time/time_formatters.hpp
+++ b/include/boost/date_time/posix_time/time_formatters.hpp
@@ -157,7 +157,7 @@ namespace posix_time {
     }// else
     return ss.str();
   }
-  //! Time duration in iso format -hhmmss,fffffff Example: 10:09:03,0123456
+  //! Time duration in iso format -hhmmss.fffffff. Example: 10:09:03.0123456
   /*!\ingroup time_format
    */
   inline std::string to_iso_string(time_duration td){
@@ -251,7 +251,7 @@ namespace posix_time {
   inline std::wstring to_simple_wstring(time_duration td) {
     return to_simple_string_type<wchar_t>(td);
   }
-  //! Time duration in iso format -hhmmss,fffffff Example: 10:09:03,0123456
+  //! Time duration in iso format -hhmmss.fffffff. Example: 10:09:03.0123456
   /*!\ingroup time_format
    */
   inline std::wstring to_iso_wstring(time_duration td){

--- a/include/boost/date_time/posix_time/time_formatters_limited.hpp
+++ b/include/boost/date_time/posix_time/time_formatters_limited.hpp
@@ -82,7 +82,7 @@ namespace posix_time {
     return ss.str();
   }
 
-  //! Time duration in iso format -hhmmss.fffffff. Example: 10:09:03.0123456
+  //! Time duration in ISO 8601 format -hhmmss.fffffff. Example: 10:09:03.0123456
   /*!\ingroup time_format
    */
   inline
@@ -173,7 +173,7 @@ namespace posix_time {
     return std::string("[" + d1 + "/" + d2 +"]");
   }
 
-  //! Convert iso short form YYYYMMDDTHHMMSS where T is the date-time separator
+  //! Convert ISO 8601 short form YYYYMMDDTHHMMSS where T is the date-time separator
   /*!\ingroup time_format
    */
   inline

--- a/include/boost/date_time/posix_time/time_formatters_limited.hpp
+++ b/include/boost/date_time/posix_time/time_formatters_limited.hpp
@@ -82,7 +82,7 @@ namespace posix_time {
     return ss.str();
   }
 
-  //! Time duration in iso format -hhmmss,fffffff Example: 10:09:03,0123456
+  //! Time duration in iso format -hhmmss.fffffff. Example: 10:09:03.0123456
   /*!\ingroup time_format
    */
   inline

--- a/include/boost/date_time/time_facet.hpp
+++ b/include/boost/date_time/time_facet.hpp
@@ -481,7 +481,7 @@ namespace date_time {
         boost::algorithm::replace_all(format, unrestricted_hours_format, hours_str);
       }
       // We still have to process restricted hours format specifier. In order to
-      // support parseability of durations in ISO format (%H%M%S), we'll have to
+      // support parseability of durations in ISO 8601 format (%H%M%S), we'll have to
       // restrict the stringified hours length to 2 characters.
       if (format.find(hours_format) != string_type::npos) {
         if (hours_str.empty())

--- a/include/boost/date_time/time_parsing.hpp
+++ b/include/boost/date_time/time_parsing.hpp
@@ -183,7 +183,7 @@ namespace date_time {
 
   }
 
-  //! Parse time duration part of an iso time of form: [-]hhmmss[.fff...] (eg: 120259.123 is 12 hours, 2 min, 59 seconds, 123000 microseconds)
+  //! Parse time duration part of an ISO 8601 time of form: [-]hhmmss[.fff...] (eg: 120259.123 is 12 hours, 2 min, 59 seconds, 123000 microseconds)
   template<class time_duration>
   inline
   time_duration

--- a/xmldoc/date_class.xml
+++ b/xmldoc/date_class.xml
@@ -132,7 +132,7 @@ date d(from_string(ds));</screen></entry>
 
         <row>
 	  <entry valign="top" morerows="1"><screen>date from_undelimited_string(std::string)</screen></entry>
-	  <entry>From iso type date string where with order year-month-day eg: 20020125</entry>
+	  <entry>From ISO 8601 type date string where with order year-month-day eg: 20020125</entry>
 	</row>
 	<row>
 	  <entry><screen>std::string ds("20020125");

--- a/xmldoc/ex_localization.xml
+++ b/xmldoc/ex_localization.xml
@@ -103,7 +103,7 @@
     us_facet->format("%m/%d/%Y");
     std::cout << d1 << std::endl; //  10/01/2002
     
-    // English names, iso order (year-month-day), '-' separator
+    // English names, ISO 8601 order (year-month-day), '-' separator
     us_facet->format("%Y-%b-%d");
     std::cout << d1 << std::endl; //  2002-Oct-01
     

--- a/xmldoc/local_time_period.xml
+++ b/xmldoc/local_time_period.xml
@@ -328,7 +328,7 @@ mar_mst.shift(hours(48));
           <!-- TODO: the streaming operators have not bee changed from time_period to local_time_period
           <row>
 	    <entry valign="top" morerows="1"><screen>operator&lt;&lt;</screen></entry>
-            <entry>Output streaming operator for time duration. Uses facet to output [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are left out when zero.</entry>
+            <entry>Output streaming operator for time duration. Uses facet to output [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
             <entry><screen>[2002-Jan-01 01:25:10.000000001/ \
@@ -337,7 +337,7 @@ mar_mst.shift(hours(48));
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>operator&gt;&gt;</screen></entry>
-            <entry>Input streaming operator for time duration. Uses facet to read [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are left out when zero.</entry>
+            <entry>Input streaming operator for time duration. Uses facet to read [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
             <entry><screen>[2002-Jan-01 01:25:10.000000001/ \

--- a/xmldoc/ptime_class.xml
+++ b/xmldoc/ptime_class.xml
@@ -345,7 +345,7 @@ pt3.is_special(); // --> false</screen></entry>
 	<tbody>
           <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_simple_string(ptime)</screen></entry>
-            <entry>To <code>YYYY-mmm-DD HH:MM:SS.fffffffff</code> string where <code>mmm</code> 3 char month name. Fractional seconds only included if non-zero.</entry>
+            <entry>To <code>YYYY-mmm-DD HH:MM:SS.fffffffff</code> string where <code>mmm</code> 3 char month name and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
 	    <entry><screen>2002-Jan-01 10:00:01.123456789</screen></entry>
@@ -353,7 +353,7 @@ pt3.is_special(); // --> false</screen></entry>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_iso_string(ptime)</screen></entry>
-            <entry>Convert to form <code>YYYYMMDDTHHMMSS.fffffffff</code> where <code>T</code> is the date-time separator</entry>
+            <entry>Convert to form <code>YYYYMMDDTHHMMSS.fffffffff</code> where <code>T</code> is the date-time separator and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
 	    <entry><screen>20020131T100001.123456789</screen></entry>
@@ -361,7 +361,7 @@ pt3.is_special(); // --> false</screen></entry>
           
           <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_iso_extended_string(ptime)</screen></entry>
-            <entry>Convert to form <code>YYYY-MM-DDTHH:MM:SS.fffffffff</code> where <code>T</code> is the date-time separator</entry>
+            <entry>Convert to form <code>YYYY-MM-DDTHH:MM:SS.fffffffff</code> where <code>T</code> is the date-time separator and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
 	    <entry><screen>2002-01-31T10:00:01.123456789</screen></entry>

--- a/xmldoc/ptime_class.xml
+++ b/xmldoc/ptime_class.xml
@@ -127,7 +127,7 @@ ptime t(time_from_string(ts))</screen></entry>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>ptime from_iso_string(std::string)</screen></entry>
-	    <entry>From non delimited iso form string.</entry>
+	    <entry>From non delimited ISO 8601 form string.</entry>
 	  </row>
           <row>
 	    <entry><screen>std::string ts("20020131T235959");
@@ -136,7 +136,7 @@ ptime t(from_iso_string(ts))</screen></entry>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>ptime from_iso_extended_string(std::string)</screen></entry>
-	    <entry>From delimited iso form string.</entry>
+	    <entry>From delimited ISO 8601 form string.</entry>
 	  </row>
           <row>
 	    <entry><screen>std::string ts("2020-01-31T23:59:59.123");

--- a/xmldoc/ptime_class.xml
+++ b/xmldoc/ptime_class.xml
@@ -353,18 +353,18 @@ pt3.is_special(); // --> false</screen></entry>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_iso_string(ptime)</screen></entry>
-            <entry>Convert to form <code>YYYYMMDDTHHMMSS,fffffffff</code> where <code>T</code> is the date-time separator</entry>
+            <entry>Convert to form <code>YYYYMMDDTHHMMSS.fffffffff</code> where <code>T</code> is the date-time separator</entry>
 	  </row>
 	  <row>
-	    <entry><screen>20020131T100001,123456789</screen></entry>
+	    <entry><screen>20020131T100001.123456789</screen></entry>
           </row>
           
           <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_iso_extended_string(ptime)</screen></entry>
-            <entry>Convert to form <code>YYYY-MM-DDTHH:MM:SS,fffffffff</code> where <code>T</code> is the date-time separator</entry>
+            <entry>Convert to form <code>YYYY-MM-DDTHH:MM:SS.fffffffff</code> where <code>T</code> is the date-time separator</entry>
 	  </row>
 	  <row>
-	    <entry><screen>2002-01-31T10:00:01,123456789</screen></entry>
+	    <entry><screen>2002-01-31T10:00:01.123456789</screen></entry>
 	  </row>
 	</tbody>
       </tgroup>

--- a/xmldoc/time_duration.xml
+++ b/xmldoc/time_duration.xml
@@ -479,7 +479,7 @@ td3.is_special(); // --> false</screen></entry>
 	<tbody>
           <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_simple_string(time_duration)</screen></entry>
-            <entry>To <code>HH:MM:SS.fffffffff</code> were <code>fff</code> is fractional seconds that are only included if non-zero.</entry>
+            <entry>To <code>HH:MM:SS.fffffffff</code> where <code>fffffffff</code> is fractional seconds that are only included if non-zero.</entry>
 	  </row>
 	  <row>
 	    <entry><screen>10:00:01.123456789</screen></entry>
@@ -487,7 +487,7 @@ td3.is_special(); // --> false</screen></entry>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_iso_string(time_duration)</screen></entry>
-            <entry>Convert to form <code>HHMMSS.fffffffff</code>.</entry>
+            <entry>Convert to form <code>HHMMSS.fffffffff</code> where the fractional seconds are only included if non-zero.</entry>
 	  </row>
           <row>
 	    <entry><screen>100001.123456789</screen></entry>

--- a/xmldoc/time_duration.xml
+++ b/xmldoc/time_duration.xml
@@ -487,10 +487,10 @@ td3.is_special(); // --> false</screen></entry>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>std::string to_iso_string(time_duration)</screen></entry>
-            <entry>Convert to form <code>HHMMSS,fffffffff</code>.</entry>
+            <entry>Convert to form <code>HHMMSS.fffffffff</code>.</entry>
 	  </row>
           <row>
-	    <entry><screen>100001,123456789</screen></entry>
+	    <entry><screen>100001.123456789</screen></entry>
 	  </row>
 	</tbody>
       </tgroup>

--- a/xmldoc/time_period.xml
+++ b/xmldoc/time_period.xml
@@ -311,7 +311,7 @@ tp2.intersects(tp1); // --> true</screen>
           <row>
             <entry valign="top" morerows="1"><screen>std::string 
   to_simple_string(time_period dp)</screen></entry>
-            <entry>To <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name.</entry>
+            <entry>To <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are only included if non-zero.</entry>
           </row>
           <row>
             <entry><screen>[2002-Jan-01 01:25:10.000000001/
@@ -341,7 +341,7 @@ tp2.intersects(tp1); // --> true</screen>
 	<tbody>
           <row>
 	    <entry valign="top" morerows="1"><screen>operator&lt;&lt;</screen></entry>
-            <entry>Output streaming operator for time duration. Uses facet to output [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are left out when zero.</entry>
+            <entry>Output streaming operator for time duration. Uses facet to output [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
             <entry><screen>[2002-Jan-01 01:25:10.000000001/ \
@@ -350,7 +350,7 @@ tp2.intersects(tp1); // --> true</screen>
 
 	  <row>
 	    <entry valign="top" morerows="1"><screen>operator&gt;&gt;</screen></entry>
-            <entry>Input streaming operator for time duration. Uses facet to read [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are left out when zero.</entry>
+            <entry>Input streaming operator for time duration. Uses facet to read [date time_of_day/date time_of_day]. The default is format is <code>[YYYY-mmm-DD hh:mm:ss.fffffffff/YYYY-mmm-DD hh:mm:ss.fffffffff]</code> string where <code>mmm</code> is 3 char month name and the fractional seconds are only included if non-zero.</entry>
 	  </row>
 	  <row>
             <entry><screen>[2002-Jan-01 01:25:10.000000001/ \


### PR DESCRIPTION
I've made a few fixes to the Boost.Date_Time documentation (including comments):

1. The fractional separator has always been implemented (back to 2002) as ".", but the documentation sometimes used ",". I've fixed the documentation
2. Consistently use "ISO 8601" to refer to the standard, instead of just "iso" or "ISO".
3. Consistently document that fractional seconds are only included if non-zero. This fixes Issue #110.