### PR TITLE
Update twinsun links in docs to use archive.org

### DIFF
--- a/xmldoc/references.xml
+++ b/xmldoc/references.xml
@@ -62,7 +62,7 @@
       <listitem><ulink url="http://www.cl.cam.ac.uk/~mgk25/c-time/">XTime C extension</ulink> proposal</listitem>
       <listitem><ulink url="http://david.tribble.com/text/c0xcalendar.html#author-info">Another C library extension proposal</ulink> by David Tribble</listitem>
       <listitem><ulink url="http://cr.yp.to/libtai.html">libTAI</ulink> is a C based time library</listitem>
-      <listitem><ulink url="http://www.twinsun.com/tz/tz-link.htm">Time Zone Database</ulink> C library for managing timezones/places</listitem>
+      <listitem><ulink url="https://web.archive.org/web/20120205224410/http://www.twinsun.com/tz/tz-link.htm">Time Zone Database</ulink> C library for managing timezones/places</listitem>
       <listitem>International Components for Unicode by IBM (open source)
 	<itemizedlist override="opencircle">
 	  <listitem><ulink url="http://icu.sourceforge.net/userguide/dateCalendar.html">Calendar Class</ulink></listitem>

--- a/xmldoc/tz_database.xml
+++ b/xmldoc/tz_database.xml
@@ -19,7 +19,7 @@
   <anchor id="tz_database_intro" />
   <bridgehead renderas="sect3">Introduction</bridgehead>
   <para>
-    The local_time system depends on the ability to store time zone information. Our Time Zone Database (tz_database) is a means of permanently storing that data. The specifications for many time zones (377 at this time) are provided. These specifications are based on data found in the <ulink url="http://www.twinsun.com/tz/tz-link.htm">zoneinfo datebase</ulink>. The specifications are stored in the file:<screen>libs/date_time/data/date_time_zonespec.csv</screen>. While this file already contains specifications for many time zones, it's real intent is for the user to modify it by adding (or removing) time zones to fit their application. See <link linkend="tz_database_datafile">Data File Details</link> to learn how this is accomplished.
+     The local_time system depends on the ability to store time zone information. Our Time Zone Database (tz_database) is a means of permanently storing that data. The specifications for many time zones (377 at this time) are provided. These specifications are based on data found in the <ulink url="https://web.archive.org/web/20120205224410/http://www.twinsun.com/tz/tz-link.htm">zoneinfo datebase</ulink>. The specifications are stored in the file:<screen>libs/date_time/data/date_time_zonespec.csv</screen>. While this file already contains specifications for many time zones, it's real intent is for the user to modify it by adding (or removing) time zones to fit their application. See <link linkend="tz_database_datafile">Data File Details</link> to learn how this is accomplished.
   </para>
 
   <anchor id="tz_database_header" />

--- a/xmldoc/tz_database.xml
+++ b/xmldoc/tz_database.xml
@@ -19,7 +19,7 @@
   <anchor id="tz_database_intro" />
   <bridgehead renderas="sect3">Introduction</bridgehead>
   <para>
-     The local_time system depends on the ability to store time zone information. Our Time Zone Database (tz_database) is a means of permanently storing that data. The specifications for many time zones (377 at this time) are provided. These specifications are based on data found in the <ulink url="https://web.archive.org/web/20120205224410/http://www.twinsun.com/tz/tz-link.htm">zoneinfo datebase</ulink>. The specifications are stored in the file:<screen>libs/date_time/data/date_time_zonespec.csv</screen>. While this file already contains specifications for many time zones, it's real intent is for the user to modify it by adding (or removing) time zones to fit their application. See <link linkend="tz_database_datafile">Data File Details</link> to learn how this is accomplished.
+    The local_time system depends on the ability to store time zone information. Our Time Zone Database (tz_database) is a means of permanently storing that data. The specifications for many time zones (377 at this time) are provided. These specifications are based on data found in the <ulink url="https://web.archive.org/web/20120205224410/http://www.twinsun.com/tz/tz-link.htm">zoneinfo datebase</ulink>. The specifications are stored in the file:<screen>libs/date_time/data/date_time_zonespec.csv</screen>. While this file already contains specifications for many time zones, it's real intent is for the user to modify it by adding (or removing) time zones to fit their application. See <link linkend="tz_database_datafile">Data File Details</link> to learn how this is accomplished.
   </para>
 
   <anchor id="tz_database_header" />


### PR DESCRIPTION
I was reading through the Boost docs today on Local Time and noticed [here](https://www.boost.org/doc/libs/1_80_0/doc/html/date_time/local_time.html#date_time.local_time.tz_database) that the link for the "zoneinfo" database is essentially dead and redirects to a NSFW webpage. Updated the link in the docs to use an older archive.org copy of the webpage with correct timezone information.