### PR TITLE
Add `as_number` to greg_year

### DIFF
--- a/include/boost/date_time/gregorian/greg_year.hpp
+++ b/include/boost/date_time/gregorian/greg_year.hpp
@@ -40,6 +40,7 @@ namespace gregorian {
   class BOOST_SYMBOL_VISIBLE greg_year : public greg_year_rep {
   public:
     BOOST_CXX14_CONSTEXPR greg_year(value_type year) : greg_year_rep(year) {}
+    BOOST_CXX14_CONSTEXPR value_type as_number() const {return value_;}
     BOOST_CXX14_CONSTEXPR operator value_type()  const {return value_;}
   };
 


### PR DESCRIPTION
for consistency with `greg_day`, `greg_month`.

This is useful e.g. for `std::format("{:02}/{:02}/{:04}", month.as_number(), day.as_number(), year.as_number())`.