### PR TITLE
Fix #233: use microsec_clock::universal_time() directly in local_time(time_zone_ptr)

### DIFF
--- a/include/boost/date_time/microsec_time_clock.hpp
+++ b/include/boost/date_time/microsec_time_clock.hpp
@@ -50,19 +50,11 @@ namespace date_time {
     typedef typename time_duration_type::rep_type resolution_traits_type;
 
     //! return a local time object for the given zone, based on computer clock
-    //JKG -- looks like we could rewrite this against universal_time
     template<class time_zone_type>
     static time_type local_time(shared_ptr<time_zone_type> tz_ptr)
     {
       typedef typename time_type::utc_time_type utc_time_type;
-      typedef second_clock<utc_time_type> second_clock;
-      // we'll need to know the utc_offset this machine has
-      // in order to get a utc_time_type set to utc
-      utc_time_type utc_time = second_clock::universal_time();
-      time_duration_type utc_offset = second_clock::local_time() - utc_time;
-      // use micro clock to get a local time with sub seconds
-      // and adjust it to get a true utc time reading with sub seconds
-      utc_time = microsec_clock<utc_time_type>::local_time() - utc_offset;
+      utc_time_type utc_time = microsec_clock<utc_time_type>::universal_time();
       return time_type(utc_time, tz_ptr);
     }
 


### PR DESCRIPTION
Fixes #233.

Calling `microsec_clock::universal_time()` directly avoids the issue where the second could change between the calls to `second_clock::local_time()` and `second_clock::universal_time()`.