### PR TITLE
issue-204: period::intersects incorrect for empty periods

### DIFF
--- a/include/boost/date_time/period.hpp
+++ b/include/boost/date_time/period.hpp
@@ -299,9 +299,7 @@ namespace date_time {
   inline BOOST_CXX14_CONSTEXPR
   bool period<point_rep,duration_rep>::intersects(const period<point_rep,duration_rep>& other) const
   { 
-    return ( contains(other.begin_) ||
-             other.contains(begin_) ||
-             ((other.begin_ < begin_) && (other.last_ >= begin_)));
+    return !is_null() && !other.is_null() && (begin_ < other.end()) && (other.begin_ < end());
   }
 
   //! Returns the period of intersection or invalid range no intersection

--- a/test/testgeneric_period.cpp
+++ b/test/testgeneric_period.cpp
@@ -125,8 +125,8 @@ int main(){
   check("Contains rep", !zero_len.contains(3));
   check("Contains period (not)", !zero_len.contains(a_period(5,8)));
   check("Contains period", p1.contains(zero_len));
-  check("Intersects", zero_len.intersects(p1));
-  check("Intersects", p1.intersects(zero_len));
+  check("Intersects", !zero_len.intersects(p1));
+  check("Intersects", !p1.intersects(zero_len));
   check("Adjacent", zero_len.is_adjacent(a_period(-10,3)));
   check("Adjacent", a_period(-10,3).is_adjacent(zero_len));
   check("Intersection", (zero_len.intersection(p1) == zero_len));
@@ -146,8 +146,8 @@ int main(){
   check("Contains rep in-between (always false)", !null_per.contains(3));
   check("Contains period (not)", !null_per.contains(a_period(7,9)));
   check("Contains period", p1.contains(null_per));
-  check("Intersects", null_per.intersects(p1));
-  check("Intersects", p1.intersects(null_per));
+  check("Intersects", !null_per.intersects(p1));
+  check("Intersects", !p1.intersects(null_per));
   check("Adjacent", null_per.is_adjacent(a_period(-10,5)));
   check("Adjacent", null_per.is_adjacent(a_period(1,10)));
 


### PR DESCRIPTION
Originally identified by Coverity Scan.  Zero length periods like [3, 3) cannot intersect with anything.  Invalid periods like [5, 4) also cannot intersect with anything.  In both cases the unit tests are wrong, and fixing them reveals the implementation is not canonical for half-open sane intervals.

In testgeneric_period.cpp there is a bug on lines 128-129; again on 149-150:

```
  check("Intersects", zero_len.intersects(p1));
  check("Intersects", p1.intersects(zero_len));
...
  check("Intersects", null_per.intersects(p1));
  check("Intersects", p1.intersects(null_per));
```

Empty (null) periods cannot intersect with anything, so the test is wrong.  Fixing the test reveals the implementation is wrong.

On simplifying the implementation of intersects to use the half-open canonical check (ensuring the half-open intervals are sane), it now passes.

```
  template<class point_rep, class duration_rep>
  inline BOOST_CXX14_CONSTEXPR
  bool period<point_rep,duration_rep>::intersects(const period<point_rep,duration_rep>& other) const
  { 
    return !is_null() && !other.is_null() && (begin_ < other.end()) && (other.begin_ < end());
  }
...
  check("Intersects", !zero_len.intersects(p1));
  check("Intersects", !p1.intersects(zero_len));
...
  check("Intersects", !null_per.intersects(p1));
  check("Intersects", !p1.intersects(null_per));
  ***passed***
```

This fixes #204 