### PR TITLE
Replace GetSystemTimeAsFileTime with GetSystemTimePreciseAsFileTime

### DIFF
--- a/include/boost/date_time/microsec_time_clock.hpp
+++ b/include/boost/date_time/microsec_time_clock.hpp
@@ -88,7 +88,7 @@ namespace date_time {
       boost::uint32_t sub_sec = tv.tv_usec;
 #elif defined(BOOST_HAS_FTIME)
       boost::winapi::FILETIME_ ft;
-      boost::winapi::GetSystemTimeAsFileTime(&ft);
+      boost::winapi::GetSystemTimePreciseAsFileTime(&ft);
 #if BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3205))
       // Some runtime library implementations expect local times as the norm for ctime functions.
       {


### PR DESCRIPTION
According to Microsoft documentation this variant of GetSystemTime guarantiees to get highest posible level of precision (<1us). https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime