### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(boost_date_time
     Boost::numeric_conversion
     Boost::range
     Boost::smart_ptr
-    Boost::static_assert
     Boost::throw_exception
     Boost::tokenizer
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ constant boost_dependencies :
     /boost/numeric_conversion//boost_numeric_conversion
     /boost/range//boost_range
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/tokenizer//boost_tokenizer
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.