### PR TITLE
Fix three parameter tags

### DIFF
--- a/include/boost/date_time/dst_rules.hpp
+++ b/include/boost/date_time/dst_rules.hpp
@@ -94,7 +94,7 @@ namespace boost {
        *  @param dst_start_offset Time offset within day for dst boundary
        *  @param dst_end_day    Ending day of dst for the given locality
        *  @param dst_end_offset Time offset within day given in dst for dst boundary
-       *  @param dst_length_minutes length of dst adjusment
+       *  @param dst_length length of dst adjusment
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
       static time_is_dst_result

--- a/include/boost/date_time/strings_from_facet.hpp
+++ b/include/boost/date_time/strings_from_facet.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace date_time {
  *  all the month strings from a locale.  This is handy when building
  *  custom date parsers or formatters that need to be localized.
  *
- *@param charT The type of char to use when gathering typically char
+ *@tparam charT The type of char to use when gathering typically char
  *             or wchar_t.
  *@param locale The locale to use when gathering the strings
  *@param short_strings True(default) to gather short strings,
@@ -73,7 +73,7 @@ gather_month_strings(const std::locale& locale, bool short_strings=true)
  *  'Sunday'.  This is handy when building custom date parsers or
  *  formatters that need to be localized.
  *
- *@param charT The type of char to use when gathering typically char
+ *@tparam charT The type of char to use when gathering typically char
  *             or wchar_t.
  *@param locale The locale to use when gathering the strings
  *@param short_strings True(default) to gather short strings,


### PR DESCRIPTION
Three Doxygen tags that do not match the declaration below them. Documentation only.

### `local_is_dst`, `dst_rules.hpp`

```cpp
 *  @param dst_length_minutes length of dst adjusment
 */
static time_is_dst_result
local_is_dst(const date_type& current_day,
             ...
             const time_duration_type& dst_length)
```

The parameter is `dst_length`. The `_minutes` suffix looks like a leftover from when it was a count rather than a `time_duration_type`; the six tags above it all match.

### `gather_month_strings` and `gather_weekday_strings`, `strings_from_facet.hpp`

```cpp
 *@param charT The type of char to use when gathering typically char
 *             or wchar_t.
 *@param locale The locale to use when gathering the strings
 */
template<typename charT>
std::vector<std::basic_string<charT> >
gather_month_strings(const std::locale& locale, bool short_strings=true)
```

`charT` is the template parameter, so it wants `@tparam`. As written, Doxygen looks for a function argument called `charT`, does not find one, and the template parameter ends up undocumented.

Both are what `clang -Wdocumentation` reports as `parameter '...' not found in the function declaration`.
